### PR TITLE
Rare-first sampling of combinations

### DIFF
--- a/outrank/core_ranking.py
+++ b/outrank/core_ranking.py
@@ -39,7 +39,7 @@ logger.setLevel(logging.DEBUG)
 random.seed(a=123, version=2)
 GLOBAL_CARDINALITY_STORAGE: dict[Any, Any] = dict()
 GLOBAL_RARE_VALUE_STORAGE: dict[str, Any] = Counter()
-GLOBAL_PRIOR_COMB_COUNTS: dict[Any, int] = dict()
+GLOBAL_PRIOR_COMB_COUNTS: dict[Any, int] = Counter()
 IGNORED_VALUES = set()
 HYPERLL_ERROR_BOUND = 0.02
 
@@ -48,22 +48,18 @@ def prior_combinations_sample(combinations: list[tuple[Any, ...]], args: Any) ->
 
     if len(GLOBAL_PRIOR_COMB_COUNTS) == 0:
         for combination in combinations:
-            update_comb_count_cache(combination)
+            GLOBAL_PRIOR_COMB_COUNTS.update({combination: 1})
         tmp = combinations[:args.combination_number_upper_bound]
     else:
         tmp = list(x[0] for x in sorted(GLOBAL_PRIOR_COMB_COUNTS.items(), key=lambda x:x[1], reverse=False))[:args.combination_number_upper_bound]
 
     for combination in tmp:
-        update_comb_count_cache(combination)
+        GLOBAL_PRIOR_COMB_COUNTS.update({combination: 1})
 
     return tmp
 
 def update_comb_count_cache(combination: tuple[Any, ...]) -> None:
-
-    if combination in GLOBAL_PRIOR_COMB_COUNTS:
-        GLOBAL_PRIOR_COMB_COUNTS[combination] += 1
-    else:
-        GLOBAL_PRIOR_COMB_COUNTS[combination] = 1
+    GLOBAL_PRIOR_COMB_COUNTS.update({combination: 1})
 
 def mixed_rank_graph(
     input_dataframe: pd.DataFrame, args: Any, cpu_pool: Any, pbar: Any,

--- a/outrank/core_ranking.py
+++ b/outrank/core_ranking.py
@@ -58,8 +58,6 @@ def prior_combinations_sample(combinations: list[tuple[Any, ...]], args: Any) ->
 
     return tmp
 
-def update_comb_count_cache(combination: tuple[Any, ...]) -> None:
-    GLOBAL_PRIOR_COMB_COUNTS.update({combination: 1})
 
 def mixed_rank_graph(
     input_dataframe: pd.DataFrame, args: Any, cpu_pool: Any, pbar: Any,

--- a/outrank/core_ranking.py
+++ b/outrank/core_ranking.py
@@ -48,13 +48,13 @@ def prior_combinations_sample(combinations: list[tuple[Any, ...]], args: Any) ->
 
     if len(GLOBAL_PRIOR_COMB_COUNTS) == 0:
         for combination in combinations:
-            GLOBAL_PRIOR_COMB_COUNTS.update({combination: 1})
+            GLOBAL_PRIOR_COMB_COUNTS[combination] += 1
         tmp = combinations[:args.combination_number_upper_bound]
     else:
         tmp = list(x[0] for x in sorted(GLOBAL_PRIOR_COMB_COUNTS.items(), key=lambda x:x[1], reverse=False))[:args.combination_number_upper_bound]
 
     for combination in tmp:
-        GLOBAL_PRIOR_COMB_COUNTS.update({combination: 1})
+        GLOBAL_PRIOR_COMB_COUNTS[combination] += 1
 
     return tmp
 

--- a/outrank/task_selftest.py
+++ b/outrank/task_selftest.py
@@ -22,7 +22,7 @@ def conduct_self_test():
         'outrank --task data_generator --num_synthetic_rows 100000', shell=True,
     )
     subprocess.run(
-        'outrank --task ranking --data_path test_data_synthetic --data_source csv-raw;',
+        'outrank --task ranking --data_path test_data_synthetic --data_source csv-raw --combination_number_upper_bound 60;',
         shell=True,
     )
 


### PR DESCRIPTION
By default, random subspaces were considered each batch. A more optimal algorithm considers the least sampled combinations each bach, overall increasing the efficiency of sampling (|F| / k (|F|=num features, k = num batches) samples are required to cover all features. The guarantee for uniform sampling is much worse, can be derived from harmonic series actually ->
![image](https://github.com/outbrain/outrank/assets/10035780/c1a38657-ad17-4903-8d5c-c1a4a5feae2c)

with 
![image](https://github.com/outbrain/outrank/assets/10035780/17aa9c72-f7e3-42fe-9dc3-383affabcbd1)
