### PR TITLE
More approximations enabled

### DIFF
--- a/outrank/__main__.py
+++ b/outrank/__main__.py
@@ -61,6 +61,12 @@ def main():
         help='A parameter that determines what proportion of vectors is considered for MI computation. 1.0 defaults to full spaces, anything below will result in subsampled spaces. This is used for faster relation estimation (3MR heuristic).',
     )
 
+    parser.add_argument(
+        '--min_support',
+        type=int,
+        default=2,
+        help='Minimal number of occurrences of an item to be considered for entropy calculation - applies to MI-numba-* algorithms.',
+    )
 
     parser.add_argument(
         '--output_folder',

--- a/outrank/__main__.py
+++ b/outrank/__main__.py
@@ -53,6 +53,15 @@ def main():
         help='Suitable for data, not pre-split to batches, this parameter determines batch size - note that too large batch size can slow down the multithreaded score computation due to many thread allocations etc. This works ok for <300 features and up to 48 threads.',
     )
 
+
+    parser.add_argument(
+        '--mi_approximation_factor',
+        type=float,
+        default=1.0,
+        help='A parameter that determines what proportion of vectors is considered for MI computation. 1.0 defaults to full spaces, anything below will result in subsampled spaces. This is used for faster relation estimation (3MR heuristic).',
+    )
+
+
     parser.add_argument(
         '--output_folder',
         type=str,

--- a/outrank/algorithms/importance_estimator.py
+++ b/outrank/algorithms/importance_estimator.py
@@ -72,7 +72,7 @@ def sklearn_surrogate(
     return estimate_feature_importance
 
 
-def numba_mi(vector_first, vector_second, heuristic, approximation_factor=1.0):
+def numba_mi(vector_first, vector_second, heuristic, approximation_factor=1.0, min_support=2):
     if heuristic == 'MI-numba-randomized':
         cardinality_correction = True
 
@@ -84,6 +84,7 @@ def numba_mi(vector_first, vector_second, heuristic, approximation_factor=1.0):
         vector_second.reshape(-1).astype(np.int32),
         approximation_factor=np.float32(approximation_factor),
         cardinality_correction=cardinality_correction,
+        min_support=min_support,
     )
 
     return estimate_feature_importance
@@ -129,16 +130,16 @@ def get_importances_estimate_pairwise(combination, args, tmp_df):
     elif args.heuristic == 'MI-numba-3mr':
         if 'AND_REL' in feature_one or 'AND_REL' in feature_two:
             estimate_feature_importance = numba_mi(
-                vector_first, vector_second, args.heuristic, args.mi_approximation_factor,
+                vector_first, vector_second, args.heuristic, args.mi_approximation_factor, args.min_support,
             )
         else:
             estimate_feature_importance = numba_mi(
-                vector_first, vector_second, args.heuristic,
+                vector_first, vector_second, args.heuristic, args.min_support,
             )
 
     elif 'MI-numba' in args.heuristic:
         estimate_feature_importance = numba_mi(
-            vector_first, vector_second, args.heuristic,
+            vector_first, vector_second, args.heuristic, args.min_support,
         )
 
     elif args.heuristic == 'AMI':

--- a/outrank/algorithms/importance_estimator.py
+++ b/outrank/algorithms/importance_estimator.py
@@ -72,7 +72,7 @@ def sklearn_surrogate(
     return estimate_feature_importance
 
 
-def numba_mi(vector_first, vector_second, heuristic):
+def numba_mi(vector_first, vector_second, heuristic, approximation_factor=1.0):
     if heuristic == 'MI-numba-randomized':
         cardinality_correction = True
 
@@ -82,7 +82,7 @@ def numba_mi(vector_first, vector_second, heuristic):
     estimate_feature_importance = ranking_mi_numba.mutual_info_estimator_numba(
         vector_first.reshape(-1).astype(np.int32),
         vector_second.reshape(-1).astype(np.int32),
-        approximation_factor=np.float32(1.0),
+        approximation_factor=np.float32(approximation_factor),
         cardinality_correction=cardinality_correction,
     )
 
@@ -125,6 +125,16 @@ def get_importances_estimate_pairwise(combination, args, tmp_df):
         estimate_feature_importance = sklearn_surrogate(
             vector_first, vector_second, args.heuristic,
         )
+
+    elif args.heuristic == 'MI-numba-3mr':
+        if 'AND_REL' in feature_one or 'AND_REL' in feature_two:
+            estimate_feature_importance = numba_mi(
+                vector_first, vector_second, args.heuristic, args.mi_approximation_factor,
+            )
+        else:
+            estimate_feature_importance = numba_mi(
+                vector_first, vector_second, args.heuristic,
+            )
 
     elif 'MI-numba' in args.heuristic:
         estimate_feature_importance = numba_mi(

--- a/outrank/core_utils.py
+++ b/outrank/core_utils.py
@@ -22,6 +22,7 @@ import xxhash
 
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
 
+
 pro_tips = [
     'OutRank can construct subfeatures; features based on subspaces. Example command argument is: --subfeature_mapping "feature_a->feature_b;feature_c<->feature_d;feature_c<->feature_e"',
     'Heuristic MI-numba-randomized seems like the best of both worlds! (speed + performance).',
@@ -91,6 +92,10 @@ class BatchRankingSummary:
 
     triplet_scores: list[tuple[str, str, float]]
     step_times: dict[str, Any]
+
+
+def display_arg_space(args: Any) -> None:
+    print('Input parameters: ' + ' | '.join(f'{k}={v}' for k, v in vars(args).items()) + '\n')
 
 
 def display_random_tip() -> None:

--- a/outrank/task_ranking.py
+++ b/outrank/task_ranking.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from outrank.algorithms.importance_estimator import rank_features_3MR
 from outrank.core_ranking import estimate_importances_minibatches
+from outrank.core_utils import display_arg_space
 from outrank.core_utils import display_random_tip
 from outrank.core_utils import display_tool_name
 from outrank.core_utils import get_dataset_info
@@ -41,6 +42,7 @@ def outrank_task_conduct_ranking(args: Any):
     if args.silent != 'True':
         display_tool_name()
         display_random_tip()
+        display_arg_space(args)
 
     dataset_info = get_dataset_info(args)
 

--- a/scripts/run_minimal.sh
+++ b/scripts/run_minimal.sh
@@ -15,7 +15,7 @@ cat avazu_sample.txt avazu_sample.txt avazu_sample.txt > tmp.txt; mv tmp.txt ava
 mkdir avazu; mv avazu_sample.txt avazu/data.csv;rm -rf avazu_sample.csv;
 
 # Run the feature ranking by using 3MR heuristic
-outrank --data_path avazu --data_source csv-raw --subsampling 1 --task all --heuristic MI-numba-randomized --target_ranking_only False --interaction_order 1 --output_folder ./ranking_outputs --minibatch_size 100 --label click --include_noise_baseline_features True;
+outrank --data_path avazu --data_source csv-raw --subsampling 1 --task all --heuristic MI-numba-3mr --target_ranking_only False --interaction_order 1 --output_folder ./ranking_outputs --minibatch_size 100 --label click --include_noise_baseline_features True;
 
 echo "Ranking outputs are present in benchmarks/ranking_outputs .."
 ls ranking_outputs;

--- a/scripts/run_minimal.sh
+++ b/scripts/run_minimal.sh
@@ -15,7 +15,7 @@ cat avazu_sample.txt avazu_sample.txt avazu_sample.txt > tmp.txt; mv tmp.txt ava
 mkdir avazu; mv avazu_sample.txt avazu/data.csv;rm -rf avazu_sample.csv;
 
 # Run the feature ranking by using 3MR heuristic
-outrank --data_path avazu --data_source csv-raw --subsampling 1 --task all --heuristic MI-numba-3mr --target_ranking_only False --interaction_order 1 --output_folder ./ranking_outputs --minibatch_size 100 --label click;
+outrank --data_path avazu --data_source csv-raw --subsampling 1 --task all --heuristic MI-numba-randomized --target_ranking_only False --interaction_order 1 --output_folder ./ranking_outputs --minibatch_size 100 --label click --include_noise_baseline_features True;
 
 echo "Ranking outputs are present in benchmarks/ranking_outputs .."
 ls ranking_outputs;

--- a/tests/mi_numba_test.py
+++ b/tests/mi_numba_test.py
@@ -17,31 +17,31 @@ class CompareStrategiesTest(unittest.TestCase):
     def test_mi_numba(self):
         a = np.random.random(10**6).reshape(-1).astype(np.int32)
         b = np.random.random(10**6).reshape(-1).astype(np.int32)
-        final_score = mutual_info_estimator_numba(a, b, np.float32(1.0), False)
+        final_score = mutual_info_estimator_numba(a, b, np.float32(1.0), False, 2)
         self.assertEqual(final_score, 0.0)
 
     def test_mi_numba_random(self):
         a = np.array([1, 0, 0, 0, 1, 1, 1, 0], dtype=np.int32)
         b = np.random.random(8).reshape(-1).astype(np.int32)
 
-        final_score = mutual_info_estimator_numba(a, b, np.float32(1.0), False)
+        final_score = mutual_info_estimator_numba(a, b, np.float32(1.0), False, 2)
         self.assertLess(final_score, 0.0)
 
     def test_mi_numba_mirror(self):
         a = np.array([1, 0, 0, 0, 1, 1, 1, 0], dtype=np.int32)
         b = np.array([1, 0, 0, 0, 1, 1, 1, 0], dtype=np.int32)
-        final_score = mutual_info_estimator_numba(a, b, np.float32(1.0), False)
+        final_score = mutual_info_estimator_numba(a, b, np.float32(1.0), False,2)
         self.assertGreater(final_score, 0.60)
 
     def test_mi_numba_longer_inputs(self):
         b = np.array([1, 0, 0, 0, 1, 1, 1, 0] * 10**5, dtype=np.int32)
-        final_score = mutual_info_estimator_numba(b, b, np.float32(1.0), False)
+        final_score = mutual_info_estimator_numba(b, b, np.float32(1.0), False, 2)
         self.assertGreater(final_score, 0.60)
 
     def test_mi_numba_permutation(self):
         a = np.array([1, 0, 0, 0, 1, 1, 1, 0] * 10**3, dtype=np.int32)
         b = np.array(np.random.permutation(a), dtype=np.int32)
-        final_score = mutual_info_estimator_numba(a, b, np.float32(1.0), False)
+        final_score = mutual_info_estimator_numba(a, b, np.float32(1.0), False, 2)
         self.assertLess(final_score, 0.05)
 
     def test_mi_numba_interaction(self):
@@ -52,13 +52,13 @@ class CompareStrategiesTest(unittest.TestCase):
         high = np.array([1, 0, 0, 0, 1, 1, 1, 1], dtype=np.int32)
 
         lowest_score = mutual_info_estimator_numba(
-            a, lowest, np.float32(1.0), False,
+            a, lowest, np.float32(1.0), False, 2,
         )
         medium_score = mutual_info_estimator_numba(
-            a, medium, np.float32(1.0), False,
+            a, medium, np.float32(1.0), False, 2,
         )
         high_score = mutual_info_estimator_numba(
-            a, high, np.float32(1.0), False,
+            a, high, np.float32(1.0), False, 2,
         )
 
         scores = [lowest_score, medium_score, high_score]
@@ -74,11 +74,11 @@ class CompareStrategiesTest(unittest.TestCase):
         ).astype(np.int32)
 
         score_independent_first = mutual_info_estimator_numba(
-            vector_first, vector_third, np.float32(1.0), False,
+            vector_first, vector_third, np.float32(1.0), False, 2,
         )
 
         score_independent_second = mutual_info_estimator_numba(
-            vector_second, vector_third, np.float32(1.0), False,
+            vector_second, vector_third, np.float32(1.0), False, 2,
         )
 
         # This must be very close to zero/negative
@@ -91,7 +91,7 @@ class CompareStrategiesTest(unittest.TestCase):
         ).astype(np.int32)
 
         score_combined = mutual_info_estimator_numba(
-            combined_feature, vector_third, np.float32(1.0), False,
+            combined_feature, vector_third, np.float32(1.0), False, 2,
         )
 
         # This must be in the range of identity


### PR DESCRIPTION
Namely,

* `--mi_approximation_factor`, a term that enables sub sampled estimation of relational space (this is mostly the bottleneck)

* `--min_support` parametrization of min support for entropy estimators. This enables skipping computation where support for a value is too small. Default is at least 2, but higher values seems to yield similar results (this has to be further evaluated).

Added also printout of arguments for easier orientation.
