### PR TITLE
Stratified sampling for some speedups

### DIFF
--- a/outrank/__main__.py
+++ b/outrank/__main__.py
@@ -49,7 +49,7 @@ def main():
     parser.add_argument(
         '--minibatch_size',
         type=int,
-        default=2**13,
+        default=2**14,
         help='Suitable for data, not pre-split to batches, this parameter determines batch size - note that too large batch size can slow down the multithreaded score computation due to many thread allocations etc. This works ok for <300 features and up to 48 threads.',
     )
 
@@ -223,6 +223,13 @@ def main():
         default='False',
         choices=['False', 'True'],
         help='Either True or False.',
+    )
+
+    parser.add_argument(
+        '--mi_stratified_sampling_ratio',
+        type=float,
+        default=1.0,
+        help='If < 1.0, MI algorithm will further subsample data in stratified manner (equal distributions per value if possible).',
     )
 
 

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba.py
@@ -115,40 +115,6 @@ def compute_entropies(
         return core_joint_entropy
 
 
-# @njit(
-#     'Tuple((int32[:], int32[:]))(int32[:], int32[:], float32, int32[:], int32[:])'
-# )
-# def stratified_subsampling(Y, X, approximation_factor, f_values_X, f_value_counts_X):
-#     all_events = len(X)
-#     f_values_Y, f_value_counts_Y = numba_unique(Y)
-
-#     final_space_size = int(approximation_factor * all_events)
-
-#     if final_space_size < 2 ** 8:
-#         return Y, X
-
-#     final_Y = np.empty(final_space_size, dtype=np.int32)
-#     final_X = np.empty(final_space_size, dtype=np.int32)
-#     unique_x_vals = len(f_values_X)
-
-#     if unique_x_vals >= final_space_size:
-#         return Y, X
-#     else:
-#         unique_samples_per_val = int(final_space_size / len(f_values_X))
-
-#     index_offset = 0
-#     for i, fval in enumerate(f_values_X):
-#         count = 0
-
-#         # todo, some randomization ..
-#         for j in range(all_events):
-#             if X[j] == fval and count < unique_samples_per_val and index_offset < final_space_size:
-#                 final_Y[index_offset] = Y[j]
-#                 final_X[index_offset] = X[j]
-#                 index_offset += 1
-#                 count += 1
-
-#     return final_Y, final_X
 @njit(
     'Tuple((int32[:], int32[:]))(int32[:], int32[:], float32, int32[:], int32[:])',
 )

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba.py
@@ -116,23 +116,19 @@ def compute_entropies(
 
 
 @njit(
-    'Tuple((int32[:], int32[:]))(int32[:], int32[:], float32, int32[:], int32[:])',
+    'Tuple((int32[:], int32[:]))(int32[:], int32[:], float32, int32[:])',
 )
-def stratified_subsampling(Y, X, approximation_factor, f_values_X, f_value_counts_X):
+def stratified_subsampling(Y, X, approximation_factor, f_values_X):
 
     all_events = len(X)
-    f_values_Y, f_value_counts_Y = numba_unique(Y)
-
     all_samples = 0
     final_space_size = int(approximation_factor * all_events)
-
-    final_Y = np.zeros(final_space_size)
-    final_X = np.zeros(final_space_size)
 
     unique_samples_per_val = int(final_space_size / len(f_values_X))
 
     if unique_samples_per_val == 0:
         return Y, X
+
     final_index_array = np.empty(final_space_size)
 
     index_offset = 0
@@ -171,7 +167,7 @@ def mutual_info_estimator_numba(
         cardinality_correction = False
 
     if approximation_factor < 1.0:
-        Y, X = stratified_subsampling(Y, X, approximation_factor, f_values, f_value_counts)
+        Y, X = stratified_subsampling(Y, X, approximation_factor, f_values)
 
     joint_entropy_core = compute_entropies(
         X, Y, all_events, f_values, f_value_counts, cardinality_correction,

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba.py
@@ -121,7 +121,6 @@ def compute_entropies(
 def stratified_subsampling(Y, X, approximation_factor, f_values_X):
 
     all_events = len(X)
-    all_samples = 0
     final_space_size = int(approximation_factor * all_events)
 
     unique_samples_per_val = int(final_space_size / len(f_values_X))

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba.py
@@ -18,12 +18,11 @@ np.random.seed(123)
 def numba_unique(a):
     """Identify unique elements in an array, fast"""
 
-    len_a = a.shape[0]
     container = np.zeros(np.max(a) + 1, dtype=np.int32)
-    for el in range(len_a):
-        container[a[el]] += 1
+    for val in a:
+        container[val] += 1
 
-    unique_values = np.where(container != 0)[0]
+    unique_values = np.nonzero(container)[0]
     unique_counts = container[unique_values]
     return unique_values.astype(np.int32), unique_counts.astype(np.int32)
 
@@ -65,7 +64,6 @@ def compute_entropies(
     conditional_entropy = 0.0
     background_cond_entropy = 0.0
     full_entropy = 0.0
-
     class_values, class_counts = numba_unique(Y)
 
     if not cardinality_correction:
@@ -117,6 +115,76 @@ def compute_entropies(
         return core_joint_entropy
 
 
+# @njit(
+#     'Tuple((int32[:], int32[:]))(int32[:], int32[:], float32, int32[:], int32[:])'
+# )
+# def stratified_subsampling(Y, X, approximation_factor, f_values_X, f_value_counts_X):
+#     all_events = len(X)
+#     f_values_Y, f_value_counts_Y = numba_unique(Y)
+
+#     final_space_size = int(approximation_factor * all_events)
+
+#     if final_space_size < 2 ** 8:
+#         return Y, X
+
+#     final_Y = np.empty(final_space_size, dtype=np.int32)
+#     final_X = np.empty(final_space_size, dtype=np.int32)
+#     unique_x_vals = len(f_values_X)
+
+#     if unique_x_vals >= final_space_size:
+#         return Y, X
+#     else:
+#         unique_samples_per_val = int(final_space_size / len(f_values_X))
+
+#     index_offset = 0
+#     for i, fval in enumerate(f_values_X):
+#         count = 0
+
+#         # todo, some randomization ..
+#         for j in range(all_events):
+#             if X[j] == fval and count < unique_samples_per_val and index_offset < final_space_size:
+#                 final_Y[index_offset] = Y[j]
+#                 final_X[index_offset] = X[j]
+#                 index_offset += 1
+#                 count += 1
+
+#     return final_Y, final_X
+@njit(
+    'Tuple((int32[:], int32[:]))(int32[:], int32[:], float32, int32[:], int32[:])',
+)
+def stratified_subsampling(Y, X, approximation_factor, f_values_X, f_value_counts_X):
+
+    all_events = len(X)
+    f_values_Y, f_value_counts_Y = numba_unique(Y)
+
+    all_samples = 0
+    final_space_size = int(approximation_factor * all_events)
+
+    final_Y = np.zeros(final_space_size)
+    final_X = np.zeros(final_space_size)
+
+    unique_samples_per_val = int(final_space_size / len(f_values_X))
+
+    if unique_samples_per_val == 0:
+        return Y, X
+    final_index_array = np.empty(final_space_size)
+
+    index_offset = 0
+    for fval in f_values_X:
+        x_indices = np.where(X == fval)[0][:unique_samples_per_val]
+        x_indices_len = len(x_indices)
+        second_offset = (index_offset + x_indices_len)
+        final_index_array[index_offset:second_offset] = x_indices
+        index_offset += x_indices_len
+
+    final_index_array = final_index_array.astype(np.int32)
+
+    X = X[final_index_array]
+    Y = Y[final_index_array]
+
+    return Y, X
+
+
 @njit(
     'float32(int32[:], int32[:], float32, b1)',
     cache=True,
@@ -125,7 +193,7 @@ def compute_entropies(
     boundscheck=True,
 )
 def mutual_info_estimator_numba(
-    Y, X, approximation_factor=1, cardinality_correction=False,
+    Y, X, approximation_factor=1.0, cardinality_correction=False,
 ):
     """Core estimator logic. Compute unique elements, subset if required"""
 
@@ -136,12 +204,8 @@ def mutual_info_estimator_numba(
     if np.sum(X - Y) == 0:
         cardinality_correction = False
 
-    if approximation_factor < 1:
-        subspace_size = int(approximation_factor * all_events)
-        if subspace_size != 0:
-            subspace = np.random.randint(0, all_events, size=subspace_size)
-            X = X[subspace]
-            Y = Y[subspace]
+    if approximation_factor < 1.0:
+        Y, X = stratified_subsampling(Y, X, approximation_factor, f_values, f_value_counts)
 
     joint_entropy_core = compute_entropies(
         X, Y, all_events, f_values, f_value_counts, cardinality_correction,
@@ -159,7 +223,7 @@ if __name__ == '__main__':
 
     final_times = []
     for algo in ['MI-numba-randomized']:
-        for order in range(20, 21):
+        for order in range(3, 4):
             for j in range(1):
                 start = time.time()
                 a = np.random.randint(1000, size=2**order).astype(np.int32)
@@ -170,7 +234,7 @@ if __name__ == '__main__':
                     )
                 elif algo == 'MI-numba-randomized':
                     final_score = mutual_info_estimator_numba(
-                        a, b, np.float32(1.0), True,
+                        a, b, np.float32(0.1), True,
                     )
                 elif algo == 'MI-numba':
                     final_score = mutual_info_estimator_numba(
@@ -193,6 +257,7 @@ if __name__ == '__main__':
                 }
                 final_times.append(instance)
                 print(instance)
+                print(final_score)
     dfx = pd.DataFrame(final_times)
     dfx = dfx.sort_values(by=['samples 2e'])
     print(dfx)

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba.py
@@ -118,12 +118,12 @@ def compute_entropies(
 @njit(
     'Tuple((int32[:], int32[:]))(int32[:], int32[:], float32, int32[:])',
 )
-def stratified_subsampling(Y, X, approximation_factor, f_values_X):
+def stratified_subsampling(Y, X, approximation_factor, _f_values_X):
 
     all_events = len(X)
     final_space_size = int(approximation_factor * all_events)
 
-    unique_samples_per_val = int(final_space_size / len(f_values_X))
+    unique_samples_per_val = int(final_space_size / len(_f_values_X))
 
     if unique_samples_per_val == 0:
         return Y, X
@@ -131,7 +131,9 @@ def stratified_subsampling(Y, X, approximation_factor, f_values_X):
     final_index_array = np.empty(final_space_size)
 
     index_offset = 0
-    for fval in f_values_X:
+    for fval in _f_values_X:
+
+        # note: this is not randomized due to batch effects, could be an improvement
         x_indices = np.where(X == fval)[0][:unique_samples_per_val]
         x_indices_len = len(x_indices)
         second_offset = (index_offset + x_indices_len)

--- a/outrank/algorithms/importance_estimator.py
+++ b/outrank/algorithms/importance_estimator.py
@@ -72,7 +72,7 @@ def sklearn_surrogate(
     return estimate_feature_importance
 
 
-def numba_mi(vector_first, vector_second, heuristic):
+def numba_mi(vector_first, vector_second, heuristic, mi_stratified_sampling_ratio):
     if heuristic == 'MI-numba-randomized':
         cardinality_correction = True
 
@@ -82,7 +82,7 @@ def numba_mi(vector_first, vector_second, heuristic):
     estimate_feature_importance = ranking_mi_numba.mutual_info_estimator_numba(
         vector_first.reshape(-1).astype(np.int32),
         vector_second.reshape(-1).astype(np.int32),
-        approximation_factor=np.float32(1.0),
+        approximation_factor=np.float32(mi_stratified_sampling_ratio),
         cardinality_correction=cardinality_correction,
     )
 
@@ -128,7 +128,7 @@ def get_importances_estimate_pairwise(combination, args, tmp_df):
 
     elif 'MI-numba' in args.heuristic:
         estimate_feature_importance = numba_mi(
-            vector_first, vector_second, args.heuristic,
+            vector_first, vector_second, args.heuristic, args.mi_stratified_sampling_ratio,
         )
 
     elif args.heuristic == 'AMI':

--- a/outrank/task_selftest.py
+++ b/outrank/task_selftest.py
@@ -29,7 +29,7 @@ def conduct_self_test():
     dfx = pd.read_csv('ranking_outputs/pairwise_ranks.tsv', sep='\t')
 
     logger.info("Verifying output's properties ..")
-    assert dfx.shape[0] == 201
+    assert dfx.shape[0] == 120
     assert dfx.shape[1] == 3
     assert dfx['FeatureA'].values.tolist().pop() == 'label-(81; 100)' or dfx['FeatureB'].values.tolist().pop() == 'label-(81; 100)'
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def _read_description():
 packages = [x for x in setuptools.find_packages() if x != 'test']
 setuptools.setup(
     name='outrank',
-    version='0.95.4',
+    version='0.95.5',
     description='OutRank: Feature ranking for massive sparse data sets.',
     long_description=_read_description(),
     long_description_content_type='text/markdown',

--- a/tests/ranking_module_test.py
+++ b/tests/ranking_module_test.py
@@ -34,6 +34,7 @@ class args:
     interaction_order: int = 3
     combination_number_upper_bound: int = 1024
     disable_tqdm: bool = False
+    mi_stratified_sampling_ratio: float = 1.0
 
 
 class CompareStrategiesTest(unittest.TestCase):


### PR DESCRIPTION
Uniform sampling is fine, but not really all that useful as we're doing that with `subsampling` anyways. Stratified sampling, however, paves the way for another round of speedups -- offline this seems to be around 100% faster (sampling=0.4) while returning more or less same rankings. It's parametrized, so simple to explore. Useful where it's ran periodically to minimize footprint ..