### PR TITLE
MCP + some algo improvements

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-unit.yml
+++ b/.github/workflows/python-unit.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "outrank": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["-m", "outrank.mcp_server"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ outrank/
 │   │   ├── feature_ranking/
 │   │   │   ├── ranking_mi_numba.py         # Numba MI (base implementation)
 │   │   │   ├── ranking_mi_numba_opt.py     # Numba MI (grouped, cache-friendly)
+│   │   │   ├── ranking_mi_numba_cmi.py     # Conditional MI, interaction info, JMI primitives
 │   │   │   ├── ranking_mi_multivalue.py    # MI for multivalue/set features
 │   │   │   └── ranking_cov_alignment.py    # Coverage-based heuristic
 │   │   ├── sketches/
@@ -50,6 +51,7 @@ outrank/
 ├── tests/                          # Unit and integration tests
 │   ├── mi_numba_test.py            # Numba MI correctness
 │   ├── mi_numba_opt_test.py        # Optimized MI correctness
+│   ├── mi_numba_cmi_test.py        # Conditional MI, interaction info, JMI
 │   ├── multivalue_mi_test.py       # Multivalue feature MI
 │   ├── hll_test.py                 # HyperLogLog accuracy
 │   ├── cms_test.py                 # Count-Min Sketch
@@ -123,8 +125,11 @@ Output: pairwise_ranks.tsv, feature_singles.tsv, visualizations
 - All new code touching algorithms **must** have a corresponding test in `tests/`
 
 ### Performance-critical code
-- Numba `@njit` decorated functions in `ranking_mi_numba.py` and `ranking_mi_numba_opt.py` — do not introduce Python objects, dynamic typing, or unsupported NumPy operations inside `@njit` functions
+- Numba `@njit` decorated functions in `ranking_mi_numba.py`, `ranking_mi_numba_opt.py`, and `ranking_mi_numba_cmi.py` — do not introduce Python objects, dynamic typing, or unsupported NumPy operations inside `@njit` functions
 - The `ranking_mi_numba_opt` variant uses pre-grouped indices for cache locality — maintain this property when modifying
+- `ranking_mi_numba_cmi.py` has two CMI paths: (1) **contingency table** (fast, O(n + dx*dy*dz), used when `cardinality_correction=False` and product <= 2M), (2) **per-Z-group** (fallback, for cardinality correction or extreme cardinality). Do not remove the fallback — it handles edge cases
+- Numba `@njit(cache=True)` functions **cannot be reliably imported cross-module** — `ranking_mi_numba_cmi.py` copies `_build_groups`/`_compute_entropies_grouped` from `ranking_mi_numba_opt.py`. Keep them in sync
+- JMI greedy selection uses **incremental score accumulation** — each step only computes CMI for the newly-selected feature, not all selected features. Do not regress to naive O(k^3) loop
 - HyperLogLog in `counting_ultiloglog.py` uses a warm-up/exact-count hybrid — the switchover threshold is `m/2`
 - `PrimitiveConstrainedCounter` has a hard size bound (default 30k) — this is intentional backpressure, not a bug
 
@@ -174,6 +179,36 @@ These are the scoring algorithms routed through `importance_estimator.conduct_fe
 | `max-value-coverage` | `ranking_cov_alignment` | Most-frequent-pair proportion |
 | `Constant` | importance_estimator | Returns 0 (placeholder) |
 | `3MR` | importance_estimator | mRMR-style multi-objective (relevance - redundancy + relational) |
+| `CMI` (via `--compute_jmi`) | `ranking_mi_numba_cmi` | Conditional MI I(X;Y\|Z), JMI greedy selection. Contingency table fast path (~2x vs per-group) |
+| `II` (via `--compute_interaction_info`) | `ranking_mi_numba_cmi` | Interaction information II(X_i,X_j;Y): synergy vs redundancy (Jakulin & Bratko convention) |
+
+## Pre-commit / CI test hook
+
+Any code addition or modification to `outrank/` or `tests/` **must** pass the following before merge:
+
+```bash
+# 1. Unit tests (all 182+ tests)
+python -m pytest tests/ -v
+
+# 2. Lint (blocking: syntax errors and undefined names)
+flake8 outrank/ --count --select=E9,F63,F7,F82 --show-source --statistics
+
+# 3. Lint (advisory: style warnings, non-blocking)
+flake8 outrank/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+# 4. Selftest (end-to-end: data generation -> ranking -> output validation)
+python -m outrank --task data_generator --num_synthetic_rows 100000
+python -m outrank --task ranking --data_path test_data_synthetic --data_source csv-raw --heuristic MI-numba-randomized --output_folder ranking_outputs
+python -c "
+import pandas as pd
+dfx = pd.read_csv('ranking_outputs/pairwise_ranks.tsv', sep='\t')
+assert dfx.shape[0] == 201 and dfx.shape[1] == 3
+print('Selftest OK')
+"
+rm -rf ranking_outputs test_data_synthetic
+```
+
+Agents **must** run steps 1-2 after every code change. Step 4 should be run before creating a PR.
 
 ## Agentic activity log
 
@@ -186,3 +221,5 @@ All significant changes made by AI agents (Claude Code, Copilot, etc.) should be
 | 2025-* | `copilot/fix-*` | Copilot | PR #108 — bug fix |
 | 2025-* | `add-llm-optimized-MI` | External contributor | PR #110 — LLM-optimized MI variant |
 | 2026-02-26 | `multivalue-improvements` | Claude Code | Created AGENTS.md documenting repository structure and agentic guidelines |
+| 2026-02-26 | `multivalue-improvements` | Claude Code | Added Conditional MI, Interaction Information, JMI feature selection (ranking_mi_numba_cmi.py, nonmyopic stub, CLI flags) |
+| 2026-02-26 | `multivalue-improvements` | Claude Code | Optimized CMI: incremental JMI scores (O(k^3)->O(k^2)), contingency table fast path (~2x), label exclusion fix. JMI overhead: <1% |

--- a/examples/jmi_xor_detection.py
+++ b/examples/jmi_xor_detection.py
@@ -1,0 +1,134 @@
+"""Demonstrates the XOR blind spot in pairwise MI and how JMI/II detect it.
+
+This script:
+1. Generates 100 random features + 2 XOR features (f0, f1) + label = XOR(f0, f1)
+2. Shows pairwise MI ranks f0, f1 near bottom (individually uninformative)
+3. Shows JMI ranking promotes f0, f1 to the top (conditionally informative)
+4. Shows interaction information: II(f0, f1; label) < 0 (synergy detected)
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from outrank.algorithms.feature_ranking.ranking_mi_numba_cmi import conditional_mutual_info_numba
+from outrank.algorithms.feature_ranking.ranking_mi_numba_cmi import interaction_information_numba
+from outrank.algorithms.feature_ranking.ranking_mi_numba_opt import (
+    mutual_info_estimator_numba_opt,
+)
+
+
+def main():
+    np.random.seed(42)
+    n = 5000
+    n_noise = 100
+
+    # Generate XOR features
+    f0 = np.random.randint(0, 2, size=n, dtype=np.int32)
+    f1 = np.random.randint(0, 2, size=n, dtype=np.int32)
+    label = np.bitwise_xor(f0, f1).astype(np.int32)
+
+    # Generate noise features (some with mild correlations to label for contrast)
+    noise_features = {}
+    for i in range(n_noise):
+        noise_features[f'noise_{i}'] = np.random.randint(0, 4, size=n, dtype=np.int32)
+
+    # Compute pairwise MI for all features
+    all_features = {'f0_xor': f0, 'f1_xor': f1, **noise_features}
+    pairwise_mi = {}
+    for name, vec in all_features.items():
+        mi = float(mutual_info_estimator_numba_opt(label, vec, np.float32(1.0), False))
+        pairwise_mi[name] = mi
+
+    pairwise_sorted = sorted(pairwise_mi.items(), key=lambda x: x[1], reverse=True)
+
+    print('=' * 60)
+    print('PAIRWISE MI RANKING (top 10 + XOR features)')
+    print('=' * 60)
+    for rank, (name, score) in enumerate(pairwise_sorted[:10], 1):
+        print(f'  #{rank:3d}  {name:20s}  MI = {score:.4f}')
+
+    # Find XOR feature ranks
+    for rank, (name, score) in enumerate(pairwise_sorted, 1):
+        if name in ('f0_xor', 'f1_xor'):
+            print(f'  #{rank:3d}  {name:20s}  MI = {score:.4f}  <-- XOR feature')
+
+    # JMI: greedy forward selection
+    print()
+    print('=' * 60)
+    print('JMI GREEDY SELECTION (first 10 features)')
+    print('=' * 60)
+
+    feature_arrays = {name: vec for name, vec in all_features.items()}
+    # Start with the top pairwise MI feature
+    selected = [pairwise_sorted[0][0]]
+    remaining = set(all_features.keys()) - set(selected)
+
+    for step in range(min(9, len(remaining))):
+        best_score = -np.inf
+        best_feat = None
+
+        for xk in remaining:
+            jmi_score = 0.0
+            for xj in selected:
+                cmi = float(
+                    conditional_mutual_info_numba(
+                        label, feature_arrays[xk], feature_arrays[xj],
+                        np.float32(1.0), False,
+                    ),
+                )
+                jmi_score += cmi
+            if jmi_score > best_score:
+                best_score = jmi_score
+                best_feat = xk
+
+        selected.append(best_feat)
+        remaining.discard(best_feat)
+
+    for rank, name in enumerate(selected, 1):
+        marker = '  <-- XOR feature' if 'xor' in name else ''
+        print(f'  #{rank:3d}  {name:20s}{marker}')
+
+    # Interaction information
+    print()
+    print('=' * 60)
+    print('INTERACTION INFORMATION')
+    print('=' * 60)
+
+    ii_xor = interaction_information_numba(label, f0, f1)
+    print(f'  II(f0_xor, f1_xor; label) = {ii_xor:.4f}')
+    print(f'  Interpretation: {"SYNERGY (negative)" if ii_xor < 0 else "REDUNDANCY (positive)" if ii_xor > 0.05 else "INDEPENDENT (~0)"}')
+    print()
+
+    # Compare with a noise pair
+    noise_0 = noise_features['noise_0']
+    noise_1 = noise_features['noise_1']
+    ii_noise = interaction_information_numba(label, noise_0, noise_1)
+    print(f'  II(noise_0, noise_1; label) = {ii_noise:.4f}')
+    print(f'  Interpretation: {"SYNERGY (negative)" if ii_noise < 0 else "REDUNDANCY (positive)" if ii_noise > 0.05 else "INDEPENDENT (~0)"}')
+
+    # Direct CMI check: I(f0; label | f1) should be high
+    cmi_f0_given_f1 = float(
+        conditional_mutual_info_numba(
+            label, f0, f1, np.float32(1.0), False,
+        ),
+    )
+    print()
+    print('=' * 60)
+    print('CONDITIONAL MI (direct synergy proof)')
+    print('=' * 60)
+    print(f'  I(f0; label)      = {pairwise_mi["f0_xor"]:.4f}  (near zero — individually uninformative)')
+    print(f'  I(f0; label | f1) = {cmi_f0_given_f1:.4f}  (high — f0 becomes informative given f1)')
+
+    print()
+    print('=' * 60)
+    print('SUMMARY')
+    print('=' * 60)
+    print('  Pairwise MI is blind to XOR: f0, f1 rank at the bottom.')
+    print('  II(f0,f1;label) < 0 detects the synergistic interaction.')
+    print('  I(f0;label|f1) >> I(f0;label) proves conditional dependence.')
+    print('  Use II to screen for synergistic pairs, then CMI/JMI to rank them.')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/multirank.py
+++ b/examples/multirank.py
@@ -50,12 +50,13 @@ def rbo_score(l1, l2, p=0.9):
 if __name__ == '__main__':
 
     # Define the number of top features to consider
-    top_n = 10
+    top_n = 30
 
+    num_datasets = 5
     # Define different sizes and corresponding folder names
-    sizes = [100000, 15000, 20000, 30000, 50000, 70000, 230000, 25000, 35000, 15000]
-    input_folders = [f'../examples/df{i+1}' for i in range(10)]
-    output_folders = [f'./output_df{i+1}' for i in range(10)]
+    sizes = [100000 * (np.random.randint(5) + 1)] * num_datasets
+    input_folders = [f'../examples/df{i+1}' for i in range(num_datasets)]
+    output_folders = [f'./output_df{i+1}' for i in range(num_datasets)]
 
     # Initialize a DataFrame to accumulate results
     accumulated_results = pd.DataFrame()

--- a/examples/run_jmi_demo.sh
+++ b/examples/run_jmi_demo.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DATA_DIR="$SCRIPT_DIR/test_data_synthetic"
+OUTPUT_DIR="/tmp/outrank_jmi_demo"
+rm -rf "$OUTPUT_DIR"
+
+if [ ! -f "$DATA_DIR/data.csv" ]; then
+  echo "Test data not found. Generating..."
+  python -m outrank --task data_generator --num_synthetic_rows 100000
+  DATA_DIR="test_data_synthetic"
+fi
+
+python -m outrank --task ranking \
+  --data_path "$DATA_DIR" \
+  --data_source csv-raw \
+  --heuristic MI-numba-randomized \
+  --compute_jmi True \
+  --compute_interaction_info True \
+  --output_folder "$OUTPUT_DIR"
+
+echo ""
+echo "=== JMI Feature Ranking (top 10) ==="
+head -11 "$OUTPUT_DIR/jmi_feature_ranking.tsv"
+
+echo ""
+echo "=== Most Synergistic Pairs (II < 0) ==="
+tail -n +2 "$OUTPUT_DIR/interaction_information.tsv" | sort -t$'\t' -k3 -g | head -5
+
+echo ""
+echo "=== Most Redundant Pairs (II > 0) ==="
+tail -n +2 "$OUTPUT_DIR/interaction_information.tsv" | sort -t$'\t' -k3 -gr | head -5
+
+echo ""
+echo "Output files in $OUTPUT_DIR/"
+ls -lh "$OUTPUT_DIR"/*.tsv

--- a/outrank/__main__.py
+++ b/outrank/__main__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import logging
 
+from outrank.cli_defaults import CLI_DEFAULTS
 from outrank.task_generators import outrank_task_generate_data_set
 from outrank.task_instance_ranking import outrank_task_rank_instances
 from outrank.task_ranking import outrank_task_conduct_ranking
@@ -34,6 +35,9 @@ usage_examples = """
     # More docs and use cases at https://outbrain.github.io/outrank/outrank.html
 """
 
+# Shorthand for default lookup — single source of truth in cli_defaults.py
+D = CLI_DEFAULTS
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -45,199 +49,199 @@ def main():
     parser.add_argument(
         '--task',
         type=str,
-        default='all',
+        default=D['task'],
         help='Type of task to consider. Can be either "ranking", "ranking_summary", "feature_summary_transformers",  or "visualization"',
     )
 
     parser.add_argument(
         '--minibatch_size',
         type=int,
-        default=2**14,
+        default=D['minibatch_size'],
         help='Suitable for data, not pre-split to batches, this parameter determines batch size - note that too large batch size can slow down the multithreaded score computation due to many thread allocations etc. This works ok for <300 features and up to 48 threads.',
     )
 
     parser.add_argument(
         '--output_folder',
         type=str,
-        default='ranking_outputs',
+        default=D['output_folder'],
         help='Output folder containing ranking results.',
     )
 
     parser.add_argument(
         '--data_source',
         type=str,
-        default='ob-vw',
+        default=D['data_source'],
         help='Which database is used to obtain learning instances? this determines the inferred folder structure (csv-raw, ob-vw, ob-csv).',
     )
 
     parser.add_argument(
         '--data_path',
         type=str,
-        default=None,
+        default=D['data_path'],
         help='Path to the folder containing the main data used for subsequent learning.',
     )
 
     parser.add_argument(
         '--subsampling',
         type=int,
-        default=10,
-        help='Subsampling ratio - every n-th instance will be considered (suggested value: 10 to 100)',
+        default=D['subsampling'],
+        help='Use every n-th row (e.g., 10 means ~10%% of data). Higher values = faster but less precise. Suggested: 10 to 100.',
     )
 
     parser.add_argument(
         '--combination_number_upper_bound',
         type=int,
-        default=2**15,
+        default=D['combination_number_upper_bound'],
         help='Cap the number of columns during feature ranking, per batch. This means that if you were to evaluate e.g., 100k combinations, this parameter results in behavior where only 2 ** 15 are taken into account (randomly) each bach, resulting in a monte-carlo like sampling scheme that yields estimates of the final ranks when all data is seen.',
     )
 
     parser.add_argument(
         '--missing_value_symbols',
         type=str,
-        default=',{}',
+        default=D['missing_value_symbols'],
         help='What symbols denote missing values? Comma-separate them - if comma is a missing symbol itself please open an issue.',
     )
 
     parser.add_argument(
         '--heuristic',
         type=str,
-        default='MI-numba-randomized',
+        default=D['heuristic'],
         help='Selected heuristic (that performs feature scoring). For full list please see the docs: https://outbrain.github.io/outrank/outrank/algorithms/importance_estimator.html',
     )
 
     parser.add_argument(
         '--include_noise_baseline_features',
         type=str,
-        default='False',
+        default=D['include_noise_baseline_features'],
         help='If enabled, it computes five control variables (random noises)',
     )
 
     parser.add_argument(
         '--include_cardinality_in_feature_names',
         type=str,
-        default='True',
+        default=D['include_cardinality_in_feature_names'],
         help='If enabled, feature names appear as feature-(cardinality) for easier inspection/debugging.',
     )
 
     parser.add_argument(
         '--image_format',
         type=str,
-        default='pdf',
+        default=D['image_format'],
         help='The format of the output images (task: visualization)',
     )
 
     parser.add_argument(
-        '--num_threads', type=int, default=8, help='Number of threads to consider. More threads implies faster ranking, however, there will be some memory overhead. Should be as large as the machine can handle memory-wise.',
+        '--num_threads', type=int, default=D['num_threads'], help='Number of threads to consider. More threads implies faster ranking, however, there will be some memory overhead. Should be as large as the machine can handle memory-wise.',
     )
 
     parser.add_argument(
         '--label_column',
         type=str,
-        default='label',
+        default=D['label_column'],
         help='Name of the target attribute for ranking. Note that this can be any other feature for most implemented heuristics.',
     )
 
     parser.add_argument(
         '--max_unique_hist_constraint',
         type=int,
-        default=30_000,
+        default=D['max_unique_hist_constraint'],
         help='Max number of unique values for which counts are recalled.',
     )
 
     parser.add_argument(
         '--transformers',
         type=str,
-        default='none',
+        default=D['transformers'],
         help='Collection of which feature transformations to consider. Examples are: fw-transformers, default, minimal. Also supports JSON file paths (e.g., custom_transformers.json) and combinations (e.g., default,custom.json)',
     )
 
     parser.add_argument(
         '--rare_value_count_upper_bound',
         type=int,
-        default=1,
+        default=D['rare_value_count_upper_bound'],
         help="When identifying rare attr-val pairs, what's the upper frequency bound?",
     )
 
     parser.add_argument(
         '--feature_set_focus',
         type=str,
-        default=None,
+        default=D['feature_set_focus'],
         help='Collection of which feature transformations to consider',
     )
 
     parser.add_argument(
         '--interaction_order',
         type=int,
-        default=1,
+        default=D['interaction_order'],
         help='The order of feature interactions to consider during ranking (complex features comprised of n elementary ones)',
     )
 
     parser.add_argument(
         '--reference_model_JSON',
         type=str,
-        default='',
+        default=D['reference_model_JSON'],
         help='Reference model JSON',
     )
 
     parser.add_argument(
         '--target_ranking_only',
         type=str,
-        default='True',
+        default=D['target_ranking_only'],
         help='Compute only the feature-label scores? This is substantially faster (O(n)).',
     )
 
     parser.add_argument(
         '--explode_multivalue_features',
         type=str,
-        default='False',
+        default=D['explode_multivalue_features'],
         help="Which ';'-separated features should be one-hot encoded into n new features (coverage analysis)",
     )
 
     parser.add_argument(
         '--subfeature_mapping',
         type=str,
-        default='False',
+        default=D['subfeature_mapping'],
         help='Compute sub-features on-the fly. Example: featureA->featureB implies features based on each value of featureA will be considered. So, feature names will correspond to values of the first feature, with actual values being constructed based on the second feature (two or more possible values).',
     )
 
     parser.add_argument(
         '--num_synthetic_features',
         type=int,
-        default=100,
+        default=D['num_synthetic_features'],
         help='Relevant for task data_generator -- how many features.',
     )
 
     parser.add_argument(
         '--tldr',
         type=str,
-        default='True',
+        default=D['tldr'],
         help='If enabled, it will output some of the main results on the screen after finishing.',
     )
 
     parser.add_argument(
         '--num_synthetic_rows',
         type=int,
-        default=1000000,
+        default=D['num_synthetic_rows'],
         help='Relevant for task data_generator -- how many rows.',
     )
 
     parser.add_argument(
         '--generator_type',
         type=str,
-        default='naive',
+        default=D['generator_type'],
         help='Relevant for task data_generator -- which generator to consider',
     )
 
     parser.add_argument(
         '--output_synthetic_df_name',
         type=str,
-        default='test_data_synthetic',
+        default=D['output_synthetic_df_name'],
         help='Relevant for task data_generator -- name of the folder that contains generated data.',
     )
 
     parser.add_argument(
         '--disable_tqdm',
-        default='False',
+        default=D['disable_tqdm'],
         choices=['False', 'True'],
         help='Either True or False.',
     )
@@ -245,35 +249,35 @@ def main():
     parser.add_argument(
         '--mi_stratified_sampling_ratio',
         type=float,
-        default=1.0,
+        default=D['mi_stratified_sampling_ratio'],
         help='If < 1.0, MI algorithm will further subsample data in stratified manner (equal distributions per value if possible).',
     )
 
     parser.add_argument(
         '--compute_jmi',
         choices=['False', 'True'],
-        default='False',
+        default=D['compute_jmi'],
         help='If True, compute JMI (Joint Mutual Information) greedy feature selection after pairwise ranking. Detects XOR-like synergies missed by pairwise MI.',
     )
 
     parser.add_argument(
         '--jmi_top_k',
         type=int,
-        default=50,
+        default=D['jmi_top_k'],
         help='Number of top pairwise-MI features to consider for JMI ranking (The Screening Rule). Higher = more thorough but slower (O(k^2) CMI calls).',
     )
 
     parser.add_argument(
         '--compute_interaction_info',
         choices=['False', 'True'],
-        default='False',
+        default=D['compute_interaction_info'],
         help='If True, compute interaction information II(X_i,X_j;Y) for top feature pairs. Negative II = synergy, positive = redundancy.',
     )
 
     parser.add_argument(
         '--interaction_info_top_k',
         type=int,
-        default=30,
+        default=D['interaction_info_top_k'],
         help='Number of top features to compute pairwise interaction information for.',
     )
 

--- a/outrank/__main__.py
+++ b/outrank/__main__.py
@@ -249,6 +249,33 @@ def main():
         help='If < 1.0, MI algorithm will further subsample data in stratified manner (equal distributions per value if possible).',
     )
 
+    parser.add_argument(
+        '--compute_jmi',
+        choices=['False', 'True'],
+        default='False',
+        help='If True, compute JMI (Joint Mutual Information) greedy feature selection after pairwise ranking. Detects XOR-like synergies missed by pairwise MI.',
+    )
+
+    parser.add_argument(
+        '--jmi_top_k',
+        type=int,
+        default=50,
+        help='Number of top pairwise-MI features to consider for JMI ranking (The Screening Rule). Higher = more thorough but slower (O(k^2) CMI calls).',
+    )
+
+    parser.add_argument(
+        '--compute_interaction_info',
+        choices=['False', 'True'],
+        default='False',
+        help='If True, compute interaction information II(X_i,X_j;Y) for top feature pairs. Negative II = synergy, positive = redundancy.',
+    )
+
+    parser.add_argument(
+        '--interaction_info_top_k',
+        type=int,
+        default=30,
+        help='Number of top features to compute pairwise interaction information for.',
+    )
 
     args = parser.parse_args()
 

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba.py
@@ -13,7 +13,7 @@ np.random.seed(123)
     cache=True,
     fastmath=True,
     error_model='numpy',
-    boundscheck=True,
+    boundscheck=False,
 )
 def numba_unique(a):
     """Identify unique elements in an array, fast"""
@@ -32,7 +32,7 @@ def numba_unique(a):
     cache=True,
     fastmath=True,
     error_model='numpy',
-    boundscheck=True,
+    boundscheck=False,
 )
 def compute_conditional_entropy(Y_classes, class_values, class_var_shape, initial_prob, nonzero_counts):
     conditional_entropy = 0.0
@@ -54,7 +54,7 @@ def compute_conditional_entropy(Y_classes, class_values, class_var_shape, initia
     parallel=False,
     fastmath=True,
     error_model='numpy',
-    boundscheck=True,
+    boundscheck=False,
 )
 def compute_entropies(
     X, Y, all_events, f_values, f_value_counts, cardinality_correction,
@@ -153,7 +153,7 @@ def stratified_subsampling(Y, X, approximation_factor, _f_values_X):
     cache=True,
     fastmath=True,
     error_model='numpy',
-    boundscheck=True,
+    boundscheck=False,
 )
 def mutual_info_estimator_numba(
     Y, X, approximation_factor=1.0, cardinality_correction=False,

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba_cmi.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba_cmi.py
@@ -142,7 +142,10 @@ def _compute_entropies_grouped(
     if not cardinality_correction:
         return full_entropy - conditional_entropy
     else:
-        return -conditional_entropy + background_cond_entropy
+        result = -conditional_entropy + background_cond_entropy
+        if result < np.float32(0.0):
+            return np.float32(0.0)
+        return result
 
 
 # --- End copied section ---
@@ -329,7 +332,10 @@ def _compute_mi_contingency_cc_local(Y, X, all_events, dx, dy):
                     p_y_given_x_s = np.float32(nxy_s) * inv_nx
                     bg_cond_entropy -= px * p_y_given_x_s * np.log(p_y_given_x_s)
 
-    return -cond_entropy + bg_cond_entropy
+    result = -cond_entropy + bg_cond_entropy
+    if result < np.float32(0.0):
+        return np.float32(0.0)
+    return result
 
 
 # --- End MI contingency table fast-paths ---

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba_cmi.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba_cmi.py
@@ -10,7 +10,7 @@ from numba import prange
 # orderings. Copying these ~60 lines is the pragmatic solution. These functions
 # must stay in sync with the originals in ranking_mi_numba_opt.py.
 
-@njit('Tuple((int32[:], int32[:]))(int32[:])', cache=True, fastmath=True)
+@njit('Tuple((int32[:], int32[:]))(int32[:])', cache=True, fastmath=True, boundscheck=False)
 def _numba_unique(a):
     maxv = 0
     if a.size > 0:
@@ -25,7 +25,7 @@ def _numba_unique(a):
     return unique_values, unique_counts
 
 
-@njit('float32(float32, int32, uint32[:])', cache=True, fastmath=True)
+@njit('float32(float32, int32, uint32[:])', cache=True, fastmath=True, boundscheck=False)
 def _compute_conditional_entropy(initial_prob, group_size, class_counts):
     ce = 0.0
     inv_group_size = 1.0 / group_size
@@ -36,7 +36,7 @@ def _compute_conditional_entropy(initial_prob, group_size, class_counts):
     return ce
 
 
-@njit('Tuple((int32[:], int32[:], int32[:], int32[:]))(int32[:])', cache=True, fastmath=True)
+@njit('Tuple((int32[:], int32[:], int32[:], int32[:]))(int32[:])', cache=True, fastmath=True, boundscheck=False)
 def _build_groups(X):
     f_values, f_counts = _numba_unique(X)
     V = f_values.size
@@ -72,6 +72,7 @@ def _build_groups(X):
     'float32(int32[:], int32, int32[:], int32[:], int32[:], int32[:], b1)',
     cache=True,
     fastmath=True,
+    boundscheck=False,
 )
 def _compute_entropies_grouped(
     Y, all_events,
@@ -147,16 +148,228 @@ def _compute_entropies_grouped(
 # --- End copied section ---
 
 
+# --- MI contingency table fast-paths (copied from ranking_mi_numba_opt.py) ---
+# Numba cross-module @njit calls with cache=True fail depending on import order.
+# These are local copies with _local suffix to avoid name collisions.
+
+@njit(
+    'float32(int32[:], int32[:], int32, int32, int32)',
+    cache=True,
+    fastmath=True,
+    boundscheck=False,
+)
+def _compute_mi_contingency_local(Y, X, all_events, dx, dy):
+    """MI(X;Y) via contingency table — no cardinality correction.
+
+    Single-pass count accumulation into flat arrays count[x,y], count[x],
+    count[y], then MI = sum p(x,y) * log(p(x,y) / (p(x)*p(y))).
+    ~2x faster than _build_groups path for moderate cardinality.
+    """
+    count_xy = np.zeros(dx * dy, dtype=np.int32)
+    count_x = np.zeros(dx, dtype=np.int32)
+    count_y = np.zeros(dy, dtype=np.int32)
+
+    for i in range(all_events):
+        x, y = X[i], Y[i]
+        count_xy[x * dy + y] += 1
+        count_x[x] += 1
+        count_y[y] += 1
+
+    inv_n = np.float32(1.0) / np.float32(all_events)
+    mi = np.float32(0.0)
+
+    for x in range(dx):
+        nx = count_x[x]
+        if nx == 0:
+            continue
+        x_off = x * dy
+        for y in range(dy):
+            nxy = count_xy[x_off + y]
+            if nxy == 0:
+                continue
+            ny = count_y[y]
+            mi += np.float32(nxy) * inv_n * np.log(
+                (np.float32(nxy) * np.float32(all_events))
+                / (np.float32(nx) * np.float32(ny)),
+            )
+
+    return mi
+
+
+@njit(
+    'Tuple((float32, float32))(int32[:], int32[:], int32[:], int32[:], int32, int32, float32)',
+    cache=True,
+    fastmath=True,
+    boundscheck=False,
+)
+def _cc_sparse_entropies_local(count_xy, count_xy_spoofed, count_x, count_y, dx, dy, inv_n):
+    """Sparse iteration for CC — extracted to keep the dense path lean for LLVM."""
+    table_size = dx * dy
+    cond_entropy = np.float32(0.0)
+    bg_cond_entropy = np.float32(0.0)
+
+    nnz_real = np.int32(0)
+    for k in range(table_size):
+        if count_xy[k] > 0:
+            nnz_real += 1
+    nz_x_r = np.empty(nnz_real, dtype=np.int32)
+    nz_nxy_r = np.empty(nnz_real, dtype=np.int32)
+    idx = np.int32(0)
+    for x in range(dx):
+        x_off = x * dy
+        for y in range(dy):
+            c = count_xy[x_off + y]
+            if c > 0:
+                nz_x_r[idx] = x
+                nz_nxy_r[idx] = c
+                idx += 1
+    for k in range(nnz_real):
+        nxy = nz_nxy_r[k]
+        nx = count_x[nz_x_r[k]]
+        if nx <= 1:
+            continue
+        px = np.float32(nx) * inv_n
+        inv_nx = np.float32(1.0) / np.float32(nx)
+        p_y_given_x = np.float32(nxy) * inv_nx
+        cond_entropy -= px * p_y_given_x * np.log(p_y_given_x)
+
+    nnz_spoof = np.int32(0)
+    for k in range(table_size):
+        if count_xy_spoofed[k] > 0:
+            nnz_spoof += 1
+    nz_x_s = np.empty(nnz_spoof, dtype=np.int32)
+    nz_nxy_s = np.empty(nnz_spoof, dtype=np.int32)
+    idx = np.int32(0)
+    for x in range(dx):
+        x_off = x * dy
+        for y in range(dy):
+            c = count_xy_spoofed[x_off + y]
+            if c > 0:
+                nz_x_s[idx] = x
+                nz_nxy_s[idx] = c
+                idx += 1
+    for k in range(nnz_spoof):
+        nxy_s = nz_nxy_s[k]
+        nx = count_x[nz_x_s[k]]
+        if nx <= 1:
+            continue
+        px = np.float32(nx) * inv_n
+        inv_nx = np.float32(1.0) / np.float32(nx)
+        p_y_given_x_s = np.float32(nxy_s) * inv_nx
+        bg_cond_entropy -= px * p_y_given_x_s * np.log(p_y_given_x_s)
+
+    return cond_entropy, bg_cond_entropy
+
+
+@njit(
+    'float32(int32[:], int32[:], int32, int32, int32)',
+    cache=True,
+    fastmath=True,
+    boundscheck=False,
+)
+def _compute_mi_contingency_cc_local(Y, X, all_events, dx, dy):
+    """MI(X;Y) with cardinality correction via contingency table.
+
+    Computes H_bg(Y|X) - H(Y|X) where H_bg uses spoofed Y assignment.
+    Sparse iteration extracted to _cc_sparse_entropies_local to avoid
+    LLVM register spill on the dense fast path.
+    """
+    n = all_events
+
+    count_xy = np.zeros(dx * dy, dtype=np.int32)
+    count_x = np.zeros(dx, dtype=np.int32)
+    count_y = np.zeros(dy, dtype=np.int32)
+
+    for i in range(n):
+        x, y = X[i], Y[i]
+        count_xy[x * dy + y] += 1
+        count_x[x] += 1
+        count_y[y] += 1
+
+    count_xy_spoofed = np.zeros(dx * dy, dtype=np.int32)
+    for i in range(n):
+        x = X[i]
+        spoofed_idx = (i + count_x[x]) % n
+        y_spoofed = Y[spoofed_idx]
+        count_xy_spoofed[x * dy + y_spoofed] += 1
+
+    inv_n = np.float32(1.0) / np.float32(n)
+    table_size = dx * dy
+
+    if table_size > 4 * n:
+        cond_entropy, bg_cond_entropy = _cc_sparse_entropies_local(
+            count_xy, count_xy_spoofed, count_x, count_y, dx, dy, inv_n,
+        )
+    else:
+        cond_entropy = np.float32(0.0)
+        bg_cond_entropy = np.float32(0.0)
+        for x in range(dx):
+            nx = count_x[x]
+            if nx <= 1:
+                continue
+            px = np.float32(nx) * inv_n
+            inv_nx = np.float32(1.0) / np.float32(nx)
+            x_off = x * dy
+            for y in range(dy):
+                nxy = count_xy[x_off + y]
+                if nxy > 0:
+                    p_y_given_x = np.float32(nxy) * inv_nx
+                    cond_entropy -= px * p_y_given_x * np.log(p_y_given_x)
+
+        for x in range(dx):
+            nx = count_x[x]
+            if nx <= 1:
+                continue
+            px = np.float32(nx) * inv_n
+            inv_nx = np.float32(1.0) / np.float32(nx)
+            x_off = x * dy
+            for y in range(dy):
+                nxy_s = count_xy_spoofed[x_off + y]
+                if nxy_s > 0:
+                    p_y_given_x_s = np.float32(nxy_s) * inv_nx
+                    bg_cond_entropy -= px * p_y_given_x_s * np.log(p_y_given_x_s)
+
+    return -cond_entropy + bg_cond_entropy
+
+
+# --- End MI contingency table fast-paths ---
+
+
 @njit(
     'float32(int32[:], int32[:], float32, b1)',
     cache=True,
     fastmath=True,
+    boundscheck=False,
 )
 def _mi_from_arrays(Y, X, approximation_factor, cardinality_correction):
     """Compute MI(X;Y) from flat int32 arrays — internal helper replicating
     the core logic of mutual_info_estimator_numba_opt without the subsampling
-    path (callers are responsible for pre-subsample)."""
+    path (callers are responsible for pre-subsample).
+
+    Dispatches to contingency table fast-path when dx*dy <= 2M, falling back
+    to _build_groups for high cardinality.
+    """
     all_events = np.int32(X.size)
+
+    # Scan max values for contingency table sizing
+    dx = np.int32(0)
+    dy = np.int32(0)
+    for i in range(all_events):
+        if X[i] > dx:
+            dx = X[i]
+        if Y[i] > dy:
+            dy = Y[i]
+    dx += np.int32(1)
+    dy += np.int32(1)
+
+    # Fast path: contingency tables when joint cardinality fits in ~8MB
+    if np.int64(dx) * np.int64(dy) <= np.int64(2_000_000):
+        if not cardinality_correction:
+            return _compute_mi_contingency_local(Y, X, all_events, dx, dy)
+        else:
+            return _compute_mi_contingency_cc_local(Y, X, all_events, dx, dy)
+
+    # Fallback: grouped approach for high cardinality
     f_values, f_counts, group_starts, positions = _build_groups(X)
     return _compute_entropies_grouped(
         Y, all_events, f_values, f_counts, group_starts, positions,
@@ -165,17 +378,66 @@ def _mi_from_arrays(Y, X, approximation_factor, cardinality_correction):
 
 
 @njit(
+    'float32(int32[:], int32[:], int32[:], int32[:], int32[:], int32, int32, int32, int32, float32)',
+    cache=True,
+    fastmath=True,
+    boundscheck=False,
+)
+def _cmi_sparse_iteration(count_xyz, count_xz, count_yz, count_z, dummy, dx, dy, dz, all_events, inv_n):
+    """Sparse iteration for 3D CMI contingency — extracted to keep the dense
+    path lean for LLVM register allocation."""
+    dy_dz = dy * dz
+    table_size = dx * dy_dz
+    cmi = np.float32(0.0)
+
+    nnz = np.int32(0)
+    for k in range(table_size):
+        if count_xyz[k] > 0:
+            nnz += 1
+
+    nz_x = np.empty(nnz, dtype=np.int32)
+    nz_y = np.empty(nnz, dtype=np.int32)
+    nz_z = np.empty(nnz, dtype=np.int32)
+    nz_count = np.empty(nnz, dtype=np.int32)
+    idx = np.int32(0)
+    for x in range(dx):
+        x_off_xyz = x * dy_dz
+        for y in range(dy):
+            y_off = y * dz
+            for z in range(dz):
+                c = count_xyz[x_off_xyz + y_off + z]
+                if c > 0:
+                    nz_x[idx] = x
+                    nz_y[idx] = y
+                    nz_z[idx] = z
+                    nz_count[idx] = c
+                    idx += 1
+
+    for k in range(nnz):
+        nxyz = nz_count[k]
+        xi, yi, zi = nz_x[k], nz_y[k], nz_z[k]
+        nxz = count_xz[xi * dz + zi]
+        nyz = count_yz[yi * dz + zi]
+        nz_val = count_z[zi]
+        cmi += np.float32(nxyz) * inv_n * np.log(
+            (np.float32(nxyz) * np.float32(nz_val))
+            / (np.float32(nxz) * np.float32(nyz)),
+        )
+    return cmi
+
+
+@njit(
     'float32(int32[:], int32[:], int32[:], int32, int32, int32, int32)',
     cache=True,
     fastmath=True,
+    boundscheck=False,
 )
 def _compute_cmi_contingency(Y, X, Z, all_events, dx, dy, dz):
     """I(X;Y|Z) via contingency tables — single-pass count accumulation.
 
-    ~2x faster than per-Z-group approach by building flat count arrays
-    count[x,y,z], count[x,z], count[y,z], count[z] in one pass over data,
-    then iterating non-zero entries to compute the CMI sum directly.
-    Avoids repeated _build_groups calls and per-group sub-array extraction.
+    ~2x faster than per-Z-group approach for moderate cardinality. Sparse
+    iteration extracted to _cmi_sparse_iteration to keep the dense path
+    small for better LLVM optimization.
     Only used when cardinality_correction is False.
     """
     dy_dz = dy * dz
@@ -193,8 +455,17 @@ def _compute_cmi_contingency(Y, X, Z, all_events, dx, dy, dz):
         count_z[z] += 1
 
     inv_n = np.float32(1.0) / np.float32(all_events)
-    cmi = np.float32(0.0)
 
+    table_size = dx * dy_dz
+    if table_size > 4 * all_events:
+        dummy = np.empty(0, dtype=np.int32)
+        return _cmi_sparse_iteration(
+            count_xyz, count_xz, count_yz, count_z, dummy,
+            dx, dy, dz, all_events, inv_n,
+        )
+
+    # Dense path: small tables fit in L1, sequential scan is optimal
+    cmi = np.float32(0.0)
     for x in range(dx):
         x_off_xyz = x * dy_dz
         x_off_xz = x * dz
@@ -206,10 +477,9 @@ def _compute_cmi_contingency(Y, X, Z, all_events, dx, dy, dz):
                     continue
                 nxz = count_xz[x_off_xz + z]
                 nyz = count_yz[y_off + z]
-                nz = count_z[z]
-                # p(x,y,z) * log( p(x,y|z) / (p(x|z) * p(y|z)) )
+                nz_val = count_z[z]
                 cmi += np.float32(nxyz) * inv_n * np.log(
-                    (np.float32(nxyz) * np.float32(nz))
+                    (np.float32(nxyz) * np.float32(nz_val))
                     / (np.float32(nxz) * np.float32(nyz)),
                 )
 
@@ -220,6 +490,7 @@ def _compute_cmi_contingency(Y, X, Z, all_events, dx, dy, dz):
     'float32(int32[:], int32[:], int32[:], int32, b1)',
     cache=True,
     fastmath=True,
+    boundscheck=False,
 )
 def _compute_cmi_core(Y, X, Z, all_events, cardinality_correction):
     """I(X;Y|Z) — dispatches to contingency table (fast) or per-Z-group (fallback).
@@ -244,6 +515,10 @@ def _compute_cmi_core(Y, X, Z, all_events, cardinality_correction):
         dx += np.int32(1)
         dy += np.int32(1)
         dz += np.int32(1)
+        # Dispatch to contingency table when total cells fit in memory (~8MB).
+        # The _compute_cmi_contingency function uses sparse iteration internally
+        # when the table density is low (table_size > 4*n), so even at card=100
+        # (1M cells) it only iterates ~n non-zero entries after collection.
         if np.int64(dx) * np.int64(dy) * np.int64(dz) <= np.int64(2_000_000):
             return _compute_cmi_contingency(Y, X, Z, all_events, dx, dy, dz)
 
@@ -320,6 +595,7 @@ def _compute_cmi_core(Y, X, Z, all_events, cardinality_correction):
     'float32(int32[:], int32[:], int32[:], float32, b1)',
     cache=True,
     fastmath=True,
+    boundscheck=False,
 )
 def conditional_mutual_info_numba(Y, X, Z, approximation_factor, cardinality_correction):
     """I(X;Y|Z) — public entry point.
@@ -368,6 +644,7 @@ def conditional_mutual_info_numba(Y, X, Z, approximation_factor, cardinality_cor
     'float32(int32[:], int32[:], int32[:], float32, b1)',
     cache=True,
     fastmath=True,
+    boundscheck=False,
 )
 def compute_joint_mi_numba(Y, X1, X2, approximation_factor, cardinality_correction):
     """I(X1,X2; Y) using integer-encoded joint feature.

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba_cmi.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba_cmi.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import numpy as np
+from numba import njit
+from numba import prange
+
+
+# --- Copied from ranking_mi_numba_opt.py ---
+# Numba cross-module @njit calls with cache=True fail under certain compilation
+# orderings. Copying these ~60 lines is the pragmatic solution. These functions
+# must stay in sync with the originals in ranking_mi_numba_opt.py.
+
+@njit('Tuple((int32[:], int32[:]))(int32[:])', cache=True, fastmath=True)
+def _numba_unique(a):
+    maxv = 0
+    if a.size > 0:
+        for i in range(a.size):
+            if a[i] > maxv:
+                maxv = a[i]
+    container = np.zeros(maxv + 1, dtype=np.int32)
+    for i in range(a.size):
+        container[a[i]] += 1
+    unique_values = np.nonzero(container)[0].astype(np.int32)
+    unique_counts = container[unique_values].astype(np.int32)
+    return unique_values, unique_counts
+
+
+@njit('float32(float32, int32, uint32[:])', cache=True, fastmath=True)
+def _compute_conditional_entropy(initial_prob, group_size, class_counts):
+    ce = 0.0
+    inv_group_size = 1.0 / group_size
+    for count in class_counts:
+        if count > 0:
+            conditional_prob = count * inv_group_size
+            ce -= initial_prob * conditional_prob * np.log(conditional_prob)
+    return ce
+
+
+@njit('Tuple((int32[:], int32[:], int32[:], int32[:]))(int32[:])', cache=True, fastmath=True)
+def _build_groups(X):
+    f_values, f_counts = _numba_unique(X)
+    V = f_values.size
+
+    vmax = 0
+    if V > 0:
+        for i in range(V):
+            if f_values[i] > vmax:
+                vmax = f_values[i]
+    value_to_group_idx = np.full(vmax + 1, -1, dtype=np.int32)
+    for i in range(V):
+        value_to_group_idx[f_values[i]] = i
+
+    group_starts = np.zeros(V, dtype=np.int32)
+    run = 0
+    for i in range(V):
+        group_starts[i] = run
+        run += f_counts[i]
+
+    positions = np.empty(X.size, dtype=np.int32)
+    cursors = group_starts.copy()
+    for i in range(X.size):
+        xi = X[i]
+        gi = value_to_group_idx[xi]
+        pos = cursors[gi]
+        positions[pos] = i
+        cursors[gi] = pos + 1
+
+    return f_values, f_counts, group_starts, positions
+
+
+@njit(
+    'float32(int32[:], int32, int32[:], int32[:], int32[:], int32[:], b1)',
+    cache=True,
+    fastmath=True,
+)
+def _compute_entropies_grouped(
+    Y, all_events,
+    f_values, f_counts, group_starts, positions,
+    cardinality_correction,
+):
+    class_values, class_counts = _numba_unique(Y)
+    C = class_values.size
+
+    full_entropy = 0.0
+    if not cardinality_correction:
+        invN = 1.0 / all_events
+        for k in range(class_counts.size):
+            p = class_counts[k] * invN
+            if p > 0.0:
+                full_entropy -= p * np.log(p)
+
+    cmax = 0
+    if C > 0:
+        for i in range(C):
+            if class_values[i] > cmax:
+                cmax = class_values[i]
+    class_to_idx = np.full(cmax + 1, -1, dtype=np.int32)
+    for i in range(C):
+        class_to_idx[class_values[i]] = i
+
+    conditional_entropy = 0.0
+    background_cond_entropy = 0.0
+    n = Y.size
+
+    hist = np.zeros(C, dtype=np.uint32)
+    hist_spoofed = np.zeros(C, dtype=np.uint32)
+
+    for gi in prange(f_values.size):
+        group_size = f_counts[gi]
+        if group_size <= 1:
+            continue
+
+        start = group_starts[gi]
+        end = start + group_size
+
+        for c in range(C):
+            hist[c] = 0
+            if cardinality_correction:
+                hist_spoofed[c] = 0
+
+        for pidx in range(start, end):
+            original_idx = positions[pidx]
+            y_val = Y[original_idx]
+            class_idx = class_to_idx[y_val]
+            hist[class_idx] += 1
+
+        if cardinality_correction:
+            shift = group_size
+            for pidx in range(start, end):
+                original_idx = positions[pidx]
+                spoofed_idx = (original_idx + shift) % n
+                y_val_spoofed = Y[spoofed_idx]
+                class_idx_spoofed = class_to_idx[y_val_spoofed]
+                hist_spoofed[class_idx_spoofed] += 1
+
+        initial_prob = group_size / all_events
+        conditional_entropy += _compute_conditional_entropy(initial_prob, group_size, hist)
+        if cardinality_correction:
+            background_cond_entropy += _compute_conditional_entropy(initial_prob, group_size, hist_spoofed)
+
+    if not cardinality_correction:
+        return full_entropy - conditional_entropy
+    else:
+        return -conditional_entropy + background_cond_entropy
+
+
+# --- End copied section ---
+
+
+@njit(
+    'float32(int32[:], int32[:], float32, b1)',
+    cache=True,
+    fastmath=True,
+)
+def _mi_from_arrays(Y, X, approximation_factor, cardinality_correction):
+    """Compute MI(X;Y) from flat int32 arrays — internal helper replicating
+    the core logic of mutual_info_estimator_numba_opt without the subsampling
+    path (callers are responsible for pre-subsample)."""
+    all_events = np.int32(X.size)
+    f_values, f_counts, group_starts, positions = _build_groups(X)
+    return _compute_entropies_grouped(
+        Y, all_events, f_values, f_counts, group_starts, positions,
+        cardinality_correction,
+    )
+
+
+@njit(
+    'float32(int32[:], int32[:], int32[:], int32, int32, int32, int32)',
+    cache=True,
+    fastmath=True,
+)
+def _compute_cmi_contingency(Y, X, Z, all_events, dx, dy, dz):
+    """I(X;Y|Z) via contingency tables — single-pass count accumulation.
+
+    ~2x faster than per-Z-group approach by building flat count arrays
+    count[x,y,z], count[x,z], count[y,z], count[z] in one pass over data,
+    then iterating non-zero entries to compute the CMI sum directly.
+    Avoids repeated _build_groups calls and per-group sub-array extraction.
+    Only used when cardinality_correction is False.
+    """
+    dy_dz = dy * dz
+
+    count_xyz = np.zeros(dx * dy_dz, dtype=np.int32)
+    count_xz = np.zeros(dx * dz, dtype=np.int32)
+    count_yz = np.zeros(dy_dz, dtype=np.int32)
+    count_z = np.zeros(dz, dtype=np.int32)
+
+    for i in range(all_events):
+        x, y, z = X[i], Y[i], Z[i]
+        count_xyz[x * dy_dz + y * dz + z] += 1
+        count_xz[x * dz + z] += 1
+        count_yz[y * dz + z] += 1
+        count_z[z] += 1
+
+    inv_n = np.float32(1.0) / np.float32(all_events)
+    cmi = np.float32(0.0)
+
+    for x in range(dx):
+        x_off_xyz = x * dy_dz
+        x_off_xz = x * dz
+        for y in range(dy):
+            y_off = y * dz
+            for z in range(dz):
+                nxyz = count_xyz[x_off_xyz + y_off + z]
+                if nxyz == 0:
+                    continue
+                nxz = count_xz[x_off_xz + z]
+                nyz = count_yz[y_off + z]
+                nz = count_z[z]
+                # p(x,y,z) * log( p(x,y|z) / (p(x|z) * p(y|z)) )
+                cmi += np.float32(nxyz) * inv_n * np.log(
+                    (np.float32(nxyz) * np.float32(nz))
+                    / (np.float32(nxz) * np.float32(nyz)),
+                )
+
+    return cmi
+
+
+@njit(
+    'float32(int32[:], int32[:], int32[:], int32, b1)',
+    cache=True,
+    fastmath=True,
+)
+def _compute_cmi_core(Y, X, Z, all_events, cardinality_correction):
+    """I(X;Y|Z) — dispatches to contingency table (fast) or per-Z-group (fallback).
+
+    Fast path: single-pass contingency tables when cardinality_correction is off
+    and the joint cardinality product is manageable (<=2M cells, ~8MB).
+    Fallback: per-Z-group partitioning with _build_groups for cardinality
+    correction or high cardinality.
+    """
+    # --- Fast path: contingency tables (no cardinality correction) ---
+    if not cardinality_correction:
+        dx = np.int32(0)
+        dy = np.int32(0)
+        dz = np.int32(0)
+        for i in range(all_events):
+            if X[i] > dx:
+                dx = X[i]
+            if Y[i] > dy:
+                dy = Y[i]
+            if Z[i] > dz:
+                dz = Z[i]
+        dx += np.int32(1)
+        dy += np.int32(1)
+        dz += np.int32(1)
+        if np.int64(dx) * np.int64(dy) * np.int64(dz) <= np.int64(2_000_000):
+            return _compute_cmi_contingency(Y, X, Z, all_events, dx, dy, dz)
+
+    # --- Fallback: per-Z-group partitioning ---
+    z_values, z_counts = _numba_unique(Z)
+    n_z = z_values.size
+
+    # Build index mapping for Z so we can extract subsets without repeated scans
+    zmax = np.int32(0)
+    for i in range(n_z):
+        if z_values[i] > zmax:
+            zmax = z_values[i]
+    z_to_idx = np.full(zmax + 1, -1, dtype=np.int32)
+    for i in range(n_z):
+        z_to_idx[z_values[i]] = i
+
+    # Pre-compute group start positions for Z
+    z_starts = np.zeros(n_z, dtype=np.int32)
+    run = np.int32(0)
+    for i in range(n_z):
+        z_starts[i] = run
+        run += z_counts[i]
+
+    z_positions = np.empty(all_events, dtype=np.int32)
+    z_cursors = z_starts.copy()
+    for i in range(all_events):
+        zi = Z[i]
+        gi = z_to_idx[zi]
+        pos = z_cursors[gi]
+        z_positions[pos] = i
+        z_cursors[gi] = pos + 1
+
+    # Allocate working arrays — sized to largest Z-group to avoid per-loop alloc
+    max_group = np.int32(0)
+    for i in range(n_z):
+        if z_counts[i] > max_group:
+            max_group = z_counts[i]
+
+    X_sub = np.empty(max_group, dtype=np.int32)
+    Y_sub = np.empty(max_group, dtype=np.int32)
+
+    cmi = np.float32(0.0)
+
+    for zi in range(n_z):
+        gz = z_counts[zi]
+        if gz <= 1:
+            continue
+
+        start = z_starts[zi]
+        for j in range(gz):
+            idx = z_positions[start + j]
+            X_sub[j] = X[idx]
+            Y_sub[j] = Y[idx]
+
+        X_slice = X_sub[:gz]
+        Y_slice = Y_sub[:gz]
+
+        # MI(X;Y) for this Z-group
+        f_values_x, f_counts_x, group_starts_x, positions_x = _build_groups(X_slice)
+        mi_z = _compute_entropies_grouped(
+            Y_slice, gz,
+            f_values_x, f_counts_x, group_starts_x, positions_x,
+            cardinality_correction,
+        )
+
+        # Weight by P(Z=z)
+        p_z = np.float32(gz) / np.float32(all_events)
+        cmi += p_z * mi_z
+
+    return cmi
+
+
+@njit(
+    'float32(int32[:], int32[:], int32[:], float32, b1)',
+    cache=True,
+    fastmath=True,
+)
+def conditional_mutual_info_numba(Y, X, Z, approximation_factor, cardinality_correction):
+    """I(X;Y|Z) — public entry point.
+
+    Validates inputs, applies optional subsampling, then delegates to the
+    core CMI computation.
+    """
+    if X.size != Y.size or X.size != Z.size:
+        # Numba doesn't support raising with message; return NaN sentinel
+        return np.float32(np.nan)
+    if X.size == 0:
+        return np.float32(0.0)
+
+    all_events = np.int32(X.size)
+
+    # Subsampling: uniform random (not stratified — three-variable stratification
+    # is combinatorially expensive and not worth it for CMI where the outer
+    # Z-conditioning already partitions the data).
+    if approximation_factor < 1.0:
+        target_n = np.int32(approximation_factor * all_events)
+        if target_n < 2:
+            target_n = np.int32(2)
+        # Deterministic stride-based subsampling for Numba compatibility
+        step = all_events // target_n
+        if step < 1:
+            step = np.int32(1)
+        actual_n = (all_events + step - 1) // step
+        X_s = np.empty(actual_n, dtype=np.int32)
+        Y_s = np.empty(actual_n, dtype=np.int32)
+        Z_s = np.empty(actual_n, dtype=np.int32)
+        idx = np.int32(0)
+        for i in range(0, all_events, step):
+            X_s[idx] = X[i]
+            Y_s[idx] = Y[i]
+            Z_s[idx] = Z[i]
+            idx += 1
+        X_s = X_s[:idx]
+        Y_s = Y_s[:idx]
+        Z_s = Z_s[:idx]
+        return _compute_cmi_core(Y_s, X_s, Z_s, idx, cardinality_correction)
+
+    return _compute_cmi_core(Y, X, Z, all_events, cardinality_correction)
+
+
+@njit(
+    'float32(int32[:], int32[:], int32[:], float32, b1)',
+    cache=True,
+    fastmath=True,
+)
+def compute_joint_mi_numba(Y, X1, X2, approximation_factor, cardinality_correction):
+    """I(X1,X2; Y) using integer-encoded joint feature.
+
+    Encodes the joint (X1,X2) as a single integer: joint = X1 * (max(X2)+1) + X2.
+    Pure integer arithmetic, no string hashing.
+    """
+    n = X1.size
+    if n == 0:
+        return np.float32(0.0)
+
+    max_x2 = np.int32(0)
+    for i in range(n):
+        if X2[i] > max_x2:
+            max_x2 = X2[i]
+    base = max_x2 + np.int32(1)
+
+    joint = np.empty(n, dtype=np.int32)
+    for i in range(n):
+        joint[i] = X1[i] * base + X2[i]
+
+    return _mi_from_arrays(Y, joint, approximation_factor, cardinality_correction)
+
+
+def interaction_information_numba(Y, X1, X2, approximation_factor=np.float32(1.0), cardinality_correction=False):
+    """II(X1, X2; Y) = I(X1;Y) + I(X2;Y) - I({X1,X2};Y)
+
+    Jakulin & Bratko convention:
+    Negative = synergy (XOR-like: features are jointly informative but
+    individually uninformative).
+    Positive = redundancy (features carry overlapping information about Y).
+    ~0 = independent contributions.
+
+    This is a pure Python function (not @njit) because it orchestrates
+    multiple Numba-compiled calls.
+    """
+    Y_i = Y.astype(np.int32)
+    X1_i = X1.astype(np.int32)
+    X2_i = X2.astype(np.int32)
+    af = np.float32(approximation_factor)
+
+    mi_x1_y = float(_mi_from_arrays(Y_i, X1_i, af, cardinality_correction))
+    mi_x2_y = float(_mi_from_arrays(Y_i, X2_i, af, cardinality_correction))
+    joint_mi = float(compute_joint_mi_numba(Y_i, X1_i, X2_i, af, cardinality_correction))
+
+    return mi_x1_y + mi_x2_y - joint_mi

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba_opt.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba_opt.py
@@ -162,7 +162,12 @@ def compute_entropies_grouped(
     if not cardinality_correction:
         return full_entropy - conditional_entropy
     else:
-        return -conditional_entropy + background_cond_entropy
+        # CC estimates can go slightly negative due to finite-sample noise;
+        # MI is non-negative by definition, so clamp to zero.
+        result = -conditional_entropy + background_cond_entropy
+        if result < np.float32(0.0):
+            return np.float32(0.0)
+        return result
 
 
 @njit(
@@ -358,7 +363,11 @@ def _compute_mi_contingency_cc(Y, X, all_events, dx, dy):
                     p_y_given_x_s = np.float32(nxy_s) * inv_nx
                     bg_cond_entropy -= px * p_y_given_x_s * np.log(p_y_given_x_s)
 
-    return -cond_entropy + bg_cond_entropy
+    # CC estimates can go slightly negative; MI is non-negative by definition.
+    result = -cond_entropy + bg_cond_entropy
+    if result < np.float32(0.0):
+        return np.float32(0.0)
+    return result
 
 
 @njit(

--- a/outrank/algorithms/feature_ranking/ranking_mi_numba_opt.py
+++ b/outrank/algorithms/feature_ranking/ranking_mi_numba_opt.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
+
 import numpy as np
-from numba import njit, prange
+from numba import njit
+from numba import prange
 
 np.random.seed(123)
 
 
-@njit('Tuple((int32[:], int32[:]))(int32[:])', cache=True, fastmath=True)
+@njit('Tuple((int32[:], int32[:]))(int32[:])', cache=True, fastmath=True, boundscheck=False)
 def numba_unique(a):
     """
     Identify unique elements and their counts in a non-negative integer array.
@@ -24,7 +26,7 @@ def numba_unique(a):
     return unique_values, unique_counts
 
 
-@njit('float32(float32, int32, uint32[:])', cache=True, fastmath=True)
+@njit('float32(float32, int32, uint32[:])', cache=True, fastmath=True, boundscheck=False)
 def compute_conditional_entropy(initial_prob, group_size, class_counts):
     """
     Calculates the contribution to conditional entropy for a single group.
@@ -41,7 +43,7 @@ def compute_conditional_entropy(initial_prob, group_size, class_counts):
     return ce
 
 
-@njit('Tuple((int32[:], int32[:], int32[:], int32[:]))(int32[:])', cache=True, fastmath=True)
+@njit('Tuple((int32[:], int32[:], int32[:], int32[:]))(int32[:])', cache=True, fastmath=True, boundscheck=False)
 def build_groups(X):
     """
     Pre-processes X to create an efficient grouping structure.
@@ -86,6 +88,7 @@ def build_groups(X):
     'float32(int32[:], int32, int32[:], int32[:], int32[:], int32[:], b1)',
     cache=True,
     fastmath=True,
+    boundscheck=False,
 )
 def compute_entropies_grouped(
     Y, all_events,
@@ -163,47 +166,246 @@ def compute_entropies_grouped(
 
 
 @njit(
-    'Tuple((int32[:], int32[:]))(int32[:], int32[:], float32, int32[:])',
+    'float32(int32[:], int32[:], int32, int32, int32)',
     cache=True,
-    fastmath=True
+    fastmath=True,
+    boundscheck=False,
 )
-def stratified_subsampling(Y, X, approximation_factor, _f_values_X):
+def _compute_mi_contingency(Y, X, all_events, dx, dy):
+    """MI(X;Y) via contingency table — single-pass count accumulation.
+
+    Builds flat count arrays count[x,y], count[x], count[y] in one pass,
+    then computes MI = sum p(x,y) * log(p(x,y) / (p(x)*p(y))) over
+    non-zero entries. ~2x faster than grouped approach for moderate
+    cardinality because it avoids build_groups overhead and per-group
+    histogram clearing.
+
+    Only used when cardinality_correction is False and dx*dy <= 2M.
     """
-    More efficient subsampling that avoids repeated np.where scans.
+    count_xy = np.zeros(dx * dy, dtype=np.int32)
+    count_x = np.zeros(dx, dtype=np.int32)
+    count_y = np.zeros(dy, dtype=np.int32)
+
+    for i in range(all_events):
+        x, y = X[i], Y[i]
+        count_xy[x * dy + y] += 1
+        count_x[x] += 1
+        count_y[y] += 1
+
+    inv_n = np.float32(1.0) / np.float32(all_events)
+    mi = np.float32(0.0)
+
+    # Dense iteration with branch-skip for zero entries. For the no-CC path
+    # (single pass), this is already optimal — sparse collection overhead
+    # negates any benefit. Sparse is only worthwhile for the CC path which
+    # iterates the table twice (see _compute_mi_contingency_cc).
+    for x in range(dx):
+        nx = count_x[x]
+        if nx == 0:
+            continue
+        x_off = x * dy
+        for y in range(dy):
+            nxy = count_xy[x_off + y]
+            if nxy == 0:
+                continue
+            ny = count_y[y]
+            mi += np.float32(nxy) * inv_n * np.log(
+                (np.float32(nxy) * np.float32(all_events))
+                / (np.float32(nx) * np.float32(ny)),
+            )
+
+    return mi
+
+
+@njit(
+    'Tuple((float32, float32))(int32[:], int32[:], int32[:], int32[:], int32, int32, float32)',
+    cache=True,
+    fastmath=True,
+    boundscheck=False,
+)
+def _cc_sparse_entropies(count_xy, count_xy_spoofed, count_x, count_y, dx, dy, inv_n):
+    """Sparse iteration for CC path — extracted to keep _compute_mi_contingency_cc
+    small so LLVM doesn't spill registers on the dense fast path."""
+    table_size = dx * dy
+    cond_entropy = np.float32(0.0)
+    bg_cond_entropy = np.float32(0.0)
+
+    # Real table: collect non-zero entries
+    nnz_real = np.int32(0)
+    for k in range(table_size):
+        if count_xy[k] > 0:
+            nnz_real += 1
+    nz_x_r = np.empty(nnz_real, dtype=np.int32)
+    nz_nxy_r = np.empty(nnz_real, dtype=np.int32)
+    idx = np.int32(0)
+    for x in range(dx):
+        x_off = x * dy
+        for y in range(dy):
+            c = count_xy[x_off + y]
+            if c > 0:
+                nz_x_r[idx] = x
+                nz_nxy_r[idx] = c
+                idx += 1
+
+    for k in range(nnz_real):
+        nxy = nz_nxy_r[k]
+        nx = count_x[nz_x_r[k]]
+        if nx <= 1:
+            continue
+        px = np.float32(nx) * inv_n
+        inv_nx = np.float32(1.0) / np.float32(nx)
+        p_y_given_x = np.float32(nxy) * inv_nx
+        cond_entropy -= px * p_y_given_x * np.log(p_y_given_x)
+
+    # Spoofed table
+    nnz_spoof = np.int32(0)
+    for k in range(table_size):
+        if count_xy_spoofed[k] > 0:
+            nnz_spoof += 1
+    nz_x_s = np.empty(nnz_spoof, dtype=np.int32)
+    nz_nxy_s = np.empty(nnz_spoof, dtype=np.int32)
+    idx = np.int32(0)
+    for x in range(dx):
+        x_off = x * dy
+        for y in range(dy):
+            c = count_xy_spoofed[x_off + y]
+            if c > 0:
+                nz_x_s[idx] = x
+                nz_nxy_s[idx] = c
+                idx += 1
+
+    for k in range(nnz_spoof):
+        nxy_s = nz_nxy_s[k]
+        nx = count_x[nz_x_s[k]]
+        if nx <= 1:
+            continue
+        px = np.float32(nx) * inv_n
+        inv_nx = np.float32(1.0) / np.float32(nx)
+        p_y_given_x_s = np.float32(nxy_s) * inv_nx
+        bg_cond_entropy -= px * p_y_given_x_s * np.log(p_y_given_x_s)
+
+    return cond_entropy, bg_cond_entropy
+
+
+@njit(
+    'float32(int32[:], int32[:], int32, int32, int32)',
+    cache=True,
+    fastmath=True,
+    boundscheck=False,
+)
+def _compute_mi_contingency_cc(Y, X, all_events, dx, dy):
+    """MI(X;Y) with cardinality correction via contingency table.
+
+    Computes H_bg(Y|X) - H(Y|X) where H_bg uses spoofed Y assignment:
+    Y_spoofed[i] = Y[(i + count_x[X[i]]) % n]. Sparse iteration extracted
+    to _cc_sparse_entropies to avoid LLVM register spill on the dense path.
+    """
+    n = all_events
+
+    # Pass 1: build real contingency table and marginals
+    count_xy = np.zeros(dx * dy, dtype=np.int32)
+    count_x = np.zeros(dx, dtype=np.int32)
+    count_y = np.zeros(dy, dtype=np.int32)
+
+    for i in range(n):
+        x, y = X[i], Y[i]
+        count_xy[x * dy + y] += 1
+        count_x[x] += 1
+        count_y[y] += 1
+
+    # Pass 2: build spoofed contingency table
+    count_xy_spoofed = np.zeros(dx * dy, dtype=np.int32)
+
+    for i in range(n):
+        x = X[i]
+        spoofed_idx = (i + count_x[x]) % n
+        y_spoofed = Y[spoofed_idx]
+        count_xy_spoofed[x * dy + y_spoofed] += 1
+
+    inv_n = np.float32(1.0) / np.float32(n)
+    table_size = dx * dy
+
+    if table_size > 4 * n:
+        cond_entropy, bg_cond_entropy = _cc_sparse_entropies(
+            count_xy, count_xy_spoofed, count_x, count_y, dx, dy, inv_n,
+        )
+    else:
+        cond_entropy = np.float32(0.0)
+        bg_cond_entropy = np.float32(0.0)
+        for x in range(dx):
+            nx = count_x[x]
+            if nx <= 1:
+                continue
+            px = np.float32(nx) * inv_n
+            inv_nx = np.float32(1.0) / np.float32(nx)
+            x_off = x * dy
+            for y in range(dy):
+                nxy = count_xy[x_off + y]
+                if nxy > 0:
+                    p_y_given_x = np.float32(nxy) * inv_nx
+                    cond_entropy -= px * p_y_given_x * np.log(p_y_given_x)
+
+        for x in range(dx):
+            nx = count_x[x]
+            if nx <= 1:
+                continue
+            px = np.float32(nx) * inv_n
+            inv_nx = np.float32(1.0) / np.float32(nx)
+            x_off = x * dy
+            for y in range(dy):
+                nxy_s = count_xy_spoofed[x_off + y]
+                if nxy_s > 0:
+                    p_y_given_x_s = np.float32(nxy_s) * inv_nx
+                    bg_cond_entropy -= px * p_y_given_x_s * np.log(p_y_given_x_s)
+
+    return -cond_entropy + bg_cond_entropy
+
+
+@njit(
+    'Tuple((int32[:], int32[:]))(int32[:], int32[:], float32, int32[:], int32[:], int32[:], int32[:])',
+    cache=True,
+    fastmath=True,
+    boundscheck=False,
+)
+def stratified_subsampling(Y, X, approximation_factor, f_values, f_counts, group_starts, positions):
+    """O(n) stratified subsampling using pre-built group structure.
+
+    Takes at most `samples_per_val` original indices from each group via
+    the positions array (already partitioned by build_groups), avoiding
+    any per-value linear scan of X.
     """
     all_events = X.size
     final_space_size = int(approximation_factor * all_events)
-    if _f_values_X.size == 0:
+    n_groups = f_values.size
+    if n_groups == 0:
         return Y, X
-    unique_samples_per_val = int(final_space_size / _f_values_X.size)
-    if unique_samples_per_val == 0:
+    samples_per_val = int(final_space_size / n_groups)
+    if samples_per_val == 0:
         return Y, X
 
     final_index_array = np.empty(final_space_size, dtype=np.int32)
-    index_offset = 0
+    offset = 0
 
-    for fval in _f_values_X:
-        count_collected = 0
-        for j in range(X.size):
-            if X[j] == fval:
-                if count_collected < unique_samples_per_val:
-                    if index_offset < final_space_size:
-                        final_index_array[index_offset] = j
-                        index_offset += 1
-                    count_collected += 1
-                else:
-                    break
+    for gi in range(n_groups):
+        start = group_starts[gi]
+        take = min(samples_per_val, f_counts[gi])
+        if offset + take > final_space_size:
+            take = final_space_size - offset
+        for j in range(take):
+            final_index_array[offset] = positions[start + j]
+            offset += 1
+        if offset >= final_space_size:
+            break
 
-    final_index_array = final_index_array[:index_offset]
-    X_sub = X[final_index_array]
-    Y_sub = Y[final_index_array]
-    return Y_sub, X_sub
+    final_index_array = final_index_array[:offset]
+    return Y[final_index_array], X[final_index_array]
 
 
 @njit(
     'float32(int32[:], int32[:], float32, b1)',
     cache=True,
     fastmath=True,
+    boundscheck=False,
 )
 def mutual_info_estimator_numba_opt(
     Y, X, approximation_factor=1.0, cardinality_correction=False,
@@ -212,35 +414,55 @@ def mutual_info_estimator_numba_opt(
     The heuristic is MI-numba-randomized, but the code for numba is structured so the execution is faster.
     Core estimator logic. This version uses the efficient grouped approach.
     """
-    
+
     if X.size != Y.size:
-        raise ValueError("Input arrays X and Y must have the same length.")
+        raise ValueError('Input arrays X and Y must have the same length.')
     if X.size == 0:
-        raise ValueError("Input arrays cannot be empty.")
-    
+        raise ValueError('Input arrays cannot be empty.')
+
     all_events = X.size
 
+    # Separate diagonal check (early exit) + max-value scan.
+    # Fusing adds ~25% per-iteration overhead from the extra branch, which
+    # hurts the common case (non-diagonal pairs where diagonal exits at i≈0).
     is_diagonal = True
-    if X.size == Y.size:
-        for i in range(X.size):
-            if X[i] != Y[i]:
-                is_diagonal = False
-                break
-    else:
-        is_diagonal = False
+    for i in range(all_events):
+        if X[i] != Y[i]:
+            is_diagonal = False
+            break
 
     if is_diagonal:
         cardinality_correction = False
 
-    if approximation_factor < 1.0:
-        f_values_full, _ = numba_unique(X)
-        Y, X = stratified_subsampling(Y, X, approximation_factor, f_values_full)
-        all_events = X.size
+    # Fast path: when no subsampling needed, try contingency table dispatch
+    # *before* paying the cost of build_groups (~100-220us).
+    if approximation_factor >= 1.0:
+        dx = np.int32(0)
+        dy = np.int32(0)
+        for i in range(all_events):
+            if X[i] > dx:
+                dx = X[i]
+            if Y[i] > dy:
+                dy = Y[i]
+        dx += np.int32(1)
+        dy += np.int32(1)
+        if np.int64(dx) * np.int64(dy) <= np.int64(2_000_000):
+            if not cardinality_correction:
+                return _compute_mi_contingency(Y, X, all_events, dx, dy)
+            else:
+                return _compute_mi_contingency_cc(Y, X, all_events, dx, dy)
 
+    # Slow path: subsampling or high-cardinality fallback — needs build_groups
     f_values, f_counts, group_starts, positions = build_groups(X)
 
+    if approximation_factor < 1.0:
+        Y, X = stratified_subsampling(Y, X, approximation_factor, f_values, f_counts, group_starts, positions)
+        all_events = X.size
+        # Rebuild groups on the subsampled data
+        f_values, f_counts, group_starts, positions = build_groups(X)
+
     joint_entropy_core = compute_entropies_grouped(
-        Y, all_events, f_values, f_counts, group_starts, positions, cardinality_correction
+        Y, all_events, f_values, f_counts, group_starts, positions, cardinality_correction,
     )
 
     return approximation_factor * joint_entropy_core

--- a/outrank/algorithms/importance_estimator.py
+++ b/outrank/algorithms/importance_estimator.py
@@ -28,12 +28,10 @@ logger.setLevel(logging.DEBUG)
 NUM_FOLDS  = 2
 SVD_DIMS = 8
 
-try:
-    from outrank.algorithms.feature_ranking import ranking_mi_numba
-    numba_available = True
-except ImportError:
-    traceback.print_exc()
-    numba_available = False
+# Lazy-import: ranking_mi_numba triggers ~520ms of Numba JIT compilation.
+# Defer until numba_mi() is actually called (dead code for default usage).
+ranking_mi_numba = None
+numba_available = True
 
 try:
     from outrank.algorithms.feature_ranking import ranking_mi_multivalue
@@ -77,6 +75,14 @@ def sklearn_surrogate(
     return 1 + np.median(scores)
 
 def numba_mi(vector_first: np.ndarray, vector_second: np.ndarray, heuristic: str, mi_stratified_sampling_ratio: float) -> float:
+    global ranking_mi_numba
+    if ranking_mi_numba is None:
+        try:
+            from outrank.algorithms.feature_ranking import ranking_mi_numba as _mod
+            ranking_mi_numba = _mod
+        except ImportError:
+            traceback.print_exc()
+            raise
     cardinality_correction = heuristic == 'MI-numba-randomized'
 
     # Vectors are already shaped correctly by generate_data_for_ranking
@@ -88,28 +94,34 @@ def numba_mi(vector_first: np.ndarray, vector_second: np.ndarray, heuristic: str
             # Multi-column case: aggregate into single column
             vector_first = np.apply_along_axis(lambda x: np.abs(np.max(x) - np.sum(x)), 1, vector_first)
 
+    # Hot path (col_arrays): arrays are already contiguous int32 from core_ranking.
+    # Safety fallback for non-col_arrays callers.
+    v1 = vector_first if vector_first.dtype == np.int32 else vector_first.astype(np.int32)
+    v2 = vector_second if vector_second.dtype == np.int32 else vector_second.astype(np.int32)
     return ranking_mi_numba.mutual_info_estimator_numba(
-        vector_first.astype(np.int32),
-        vector_second.astype(np.int32),
+        v1, v2,
         approximation_factor=np.float32(mi_stratified_sampling_ratio),
         cardinality_correction=cardinality_correction,
     )
 
 def numba_mi_opt(vector_first: np.ndarray, vector_second: np.ndarray, heuristic: str, mi_stratified_sampling_ratio: float) -> float:
 
-    cardinality_correction = heuristic == 'MI-numba-randomized-opt'
+    cardinality_correction = 'randomized' in heuristic
 
-    # Preprocess vector_first to ensure it is a 1D array. This handles cases
-    # where features might be multi-column (e.g., one-hot encoded).
+    # Ensure 1D. generate_data_for_ranking now skips reshape for Numba
+    # heuristics, so this is typically a no-op. Kept for safety.
     if vector_first.ndim == 2:
         if vector_first.shape[1] > 1:
             vector_first = np.apply_along_axis(lambda x: np.abs(np.max(x) - np.sum(x)), 1, vector_first)
         else:
-            vector_first = vector_first.reshape(-1)
+            vector_first = vector_first.ravel()
 
+    # Hot path (col_arrays): arrays are already contiguous int32 from core_ranking.
+    # Safety fallback for non-col_arrays callers (tests, standalone usage).
+    v1 = vector_first if vector_first.dtype == np.int32 else vector_first.astype(np.int32)
+    v2 = vector_second if vector_second.dtype == np.int32 else vector_second.astype(np.int32)
     return ranking_mi_numba_opt.mutual_info_estimator_numba_opt(
-        vector_first.astype(np.int32),
-        vector_second.astype(np.int32),
+        v1, v2,
         approximation_factor=np.float32(mi_stratified_sampling_ratio),
         cardinality_correction=cardinality_correction,
     )
@@ -173,11 +185,12 @@ def numba_cmi(vector_first: np.ndarray, vector_second: np.ndarray, vector_condit
     if vector_condition.ndim == 2:
         vector_condition = vector_condition[:, 0] if vector_condition.shape[1] == 1 else np.apply_along_axis(lambda x: np.abs(np.max(x) - np.sum(x)), 1, vector_condition)
 
+    v1 = vector_first if vector_first.dtype == np.int32 else vector_first.astype(np.int32)
+    v2 = vector_second if vector_second.dtype == np.int32 else vector_second.astype(np.int32)
+    vc = vector_condition if vector_condition.dtype == np.int32 else vector_condition.astype(np.int32)
     return float(
         ranking_mi_numba_cmi.conditional_mutual_info_numba(
-            vector_second.astype(np.int32),
-            vector_first.astype(np.int32),
-            vector_condition.astype(np.int32),
+            v2, v1, vc,
             np.float32(mi_stratified_sampling_ratio),
             cardinality_correction,
         ),
@@ -191,16 +204,17 @@ def numba_interaction_info(vector_x1: np.ndarray, vector_x2: np.ndarray, vector_
     if vector_x2.ndim == 2:
         vector_x2 = vector_x2[:, 0] if vector_x2.shape[1] == 1 else np.apply_along_axis(lambda x: np.abs(np.max(x) - np.sum(x)), 1, vector_x2)
 
+    vy = vector_y if vector_y.dtype == np.int32 else vector_y.astype(np.int32)
+    vx1 = vector_x1 if vector_x1.dtype == np.int32 else vector_x1.astype(np.int32)
+    vx2 = vector_x2 if vector_x2.dtype == np.int32 else vector_x2.astype(np.int32)
     return ranking_mi_numba_cmi.interaction_information_numba(
-        vector_y.astype(np.int32),
-        vector_x1.astype(np.int32),
-        vector_x2.astype(np.int32),
+        vy, vx1, vx2,
         np.float32(mi_stratified_sampling_ratio),
         cardinality_correction,
     )
 
 
-def generate_data_for_ranking(combination: tuple[str, str], reference_model_features: list[str], args: Any, tmp_df: pd.DataFrame) -> tuple(np.ndarray, np.ndrray):
+def generate_data_for_ranking(combination: tuple[str, str], reference_model_features: list[str], args: Any, tmp_df: pd.DataFrame = None, col_arrays: dict | None = None) -> tuple:
     feature_one, feature_two = combination
 
     if feature_one == args.label_column:
@@ -209,15 +223,22 @@ def generate_data_for_ranking(combination: tuple[str, str], reference_model_feat
 
     if args.reference_model_JSON:
         vector_first = tmp_df[list(reference_model_features) + [feature_one]].values
+    elif col_arrays is not None:
+        vector_first = col_arrays[feature_one]
     else:
         vector_first = tmp_df[feature_one].values
 
-    vector_second = tmp_df[feature_two].values
+    if col_arrays is not None:
+        vector_second = col_arrays[feature_two]
+    else:
+        vector_second = tmp_df[feature_two].values
 
-    # Ensure vectors have consistent shape to avoid repeated reshaping downstream
-    # vector_first can be 1D or 2D (multi-column), vector_second is always 1D
-    if vector_first.ndim == 1:
-        vector_first = vector_first.reshape(-1, 1)
+    # Numba heuristics operate on 1D int32 arrays — skip the 2D reshape round-trip.
+    # sklearn heuristics expect (n,1) for vector_first.
+    _numba_heuristics = {'MI-numba-randomized', 'MI-numba-randomized-opt'}
+    if args.heuristic not in _numba_heuristics:
+        if vector_first.ndim == 1:
+            vector_first = vector_first.reshape(-1, 1)
     if vector_second.ndim != 1:
         vector_second = vector_second.reshape(-1)
 
@@ -238,10 +259,7 @@ def conduct_feature_ranking(vector_first: np.ndarray, vector_second: np.ndarray,
     elif heuristic == 'max-value-coverage':
         score = ranking_cov_alignment.max_pair_coverage(vector_first, vector_second)
 
-    elif heuristic == 'MI-numba-randomized':
-        score = numba_mi(vector_first, vector_second, heuristic, args.mi_stratified_sampling_ratio)
-
-    elif heuristic == 'MI-numba-randomized-opt':
+    elif heuristic in {'MI-numba-randomized', 'MI-numba-randomized-opt'}:
         score = numba_mi_opt(vector_first, vector_second, heuristic, args.mi_stratified_sampling_ratio)
 
     elif heuristic == 'AMI':
@@ -273,10 +291,10 @@ def conduct_feature_ranking(vector_first: np.ndarray, vector_second: np.ndarray,
 
     return score
 
-def get_importances_estimate_pairwise(combination: tuple[str, str], reference_model_features: list[str], args: Any, tmp_df: pd.DataFrame) -> tuple[str, str, float]:
+def get_importances_estimate_pairwise(combination: tuple[str, str], reference_model_features: list[str], args: Any, tmp_df: pd.DataFrame = None, col_arrays: dict | None = None) -> tuple[str, str, float]:
 
     feature_one, feature_two = combination
-    inputs_encoded, output_encoded = generate_data_for_ranking(combination, reference_model_features, args, tmp_df)
+    inputs_encoded, output_encoded = generate_data_for_ranking(combination, reference_model_features, args, tmp_df, col_arrays=col_arrays)
 
     ranking_score = conduct_feature_ranking(inputs_encoded, output_encoded, args)
 

--- a/outrank/algorithms/importance_estimator.py
+++ b/outrank/algorithms/importance_estimator.py
@@ -19,7 +19,8 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.svm import SVC
 
-from outrank.algorithms.feature_ranking import ranking_cov_alignment, ranking_mi_numba_opt
+from outrank.algorithms.feature_ranking import ranking_cov_alignment
+from outrank.algorithms.feature_ranking import ranking_mi_numba_opt
 
 logger = logging.getLogger('syn-logger')
 logger.setLevel(logging.DEBUG)
@@ -40,6 +41,13 @@ try:
 except ImportError:
     traceback.print_exc()
     multivalue_available = False
+
+try:
+    from outrank.algorithms.feature_ranking import ranking_mi_numba_cmi
+    cmi_available = True
+except ImportError:
+    traceback.print_exc()
+    cmi_available = False
 
 def sklearn_MI(vector_first: np.ndarray, vector_second: np.ndarray) -> float:
     # Vectors are already shaped correctly by generate_data_for_ranking
@@ -86,7 +94,7 @@ def numba_mi(vector_first: np.ndarray, vector_second: np.ndarray, heuristic: str
         approximation_factor=np.float32(mi_stratified_sampling_ratio),
         cardinality_correction=cardinality_correction,
     )
-    
+
 def numba_mi_opt(vector_first: np.ndarray, vector_second: np.ndarray, heuristic: str, mi_stratified_sampling_ratio: float) -> float:
 
     cardinality_correction = heuristic == 'MI-numba-randomized-opt'
@@ -116,12 +124,12 @@ def multivalue_mi_jaccard(vector_first: np.ndarray, vector_second: np.ndarray) -
     if not multivalue_available:
         logger.warning('Multivalue MI not available, falling back to standard MI')
         return sklearn_MI(vector_first, vector_second)
-    
+
     # Multivalue MI expects 1D arrays of strings
     v1 = vector_first.reshape(-1) if vector_first.ndim > 1 else vector_first
     v2 = vector_second.reshape(-1) if vector_second.ndim > 1 else vector_second
     return ranking_mi_multivalue.multivalue_mutual_info_estimator(
-        v1, v2, algorithm='jaccard'
+        v1, v2, algorithm='jaccard',
     )
 
 def multivalue_mi_overlap(vector_first: np.ndarray, vector_second: np.ndarray) -> float:
@@ -129,32 +137,68 @@ def multivalue_mi_overlap(vector_first: np.ndarray, vector_second: np.ndarray) -
     if not multivalue_available:
         logger.warning('Multivalue MI not available, falling back to standard MI')
         return sklearn_MI(vector_first, vector_second)
-    
+
     # Multivalue MI expects 1D arrays of strings
     v1 = vector_first.reshape(-1) if vector_first.ndim > 1 else vector_first
     v2 = vector_second.reshape(-1) if vector_second.ndim > 1 else vector_second
     return ranking_mi_multivalue.multivalue_mutual_info_estimator(
-        v1, v2, algorithm='overlap'
+        v1, v2, algorithm='overlap',
     )
 
 def multivalue_mi_set_based(vector_first: np.ndarray, vector_second: np.ndarray, cardinality_correction: bool = False) -> float:
     """Compute mutual information between multivalue features using set-based approach.
-    
+
     Args:
         vector_first: First multivalue feature vector
         vector_second: Second multivalue feature vector
         cardinality_correction: If True, apply cardinality correction to prevent inflation
-    """ 
+    """
     if not multivalue_available:
         logger.warning('Multivalue MI not available, falling back to standard MI')
         return sklearn_MI(vector_first, vector_second)
-    
+
     # Multivalue MI expects 1D arrays of strings
     v1 = vector_first.reshape(-1) if vector_first.ndim > 1 else vector_first
     v2 = vector_second.reshape(-1) if vector_second.ndim > 1 else vector_second
     return ranking_mi_multivalue.multivalue_mutual_info_estimator(
-        v1, v2, algorithm='set_based', cardinality_correction=cardinality_correction
+        v1, v2, algorithm='set_based', cardinality_correction=cardinality_correction,
     )
+
+def numba_cmi(vector_first: np.ndarray, vector_second: np.ndarray, vector_condition: np.ndarray, heuristic: str, mi_stratified_sampling_ratio: float) -> float:
+    """Compute I(X;Y|Z) using the Numba-JIT'd CMI kernel."""
+    cardinality_correction = 'randomized' in heuristic
+
+    if vector_first.ndim == 2:
+        vector_first = vector_first[:, 0] if vector_first.shape[1] == 1 else np.apply_along_axis(lambda x: np.abs(np.max(x) - np.sum(x)), 1, vector_first)
+    if vector_condition.ndim == 2:
+        vector_condition = vector_condition[:, 0] if vector_condition.shape[1] == 1 else np.apply_along_axis(lambda x: np.abs(np.max(x) - np.sum(x)), 1, vector_condition)
+
+    return float(
+        ranking_mi_numba_cmi.conditional_mutual_info_numba(
+            vector_second.astype(np.int32),
+            vector_first.astype(np.int32),
+            vector_condition.astype(np.int32),
+            np.float32(mi_stratified_sampling_ratio),
+            cardinality_correction,
+        ),
+    )
+
+
+def numba_interaction_info(vector_x1: np.ndarray, vector_x2: np.ndarray, vector_y: np.ndarray, mi_stratified_sampling_ratio: float = 1.0, cardinality_correction: bool = False) -> float:
+    """Compute II(X1, X2; Y) using the Jakulin & Bratko convention."""
+    if vector_x1.ndim == 2:
+        vector_x1 = vector_x1[:, 0] if vector_x1.shape[1] == 1 else np.apply_along_axis(lambda x: np.abs(np.max(x) - np.sum(x)), 1, vector_x1)
+    if vector_x2.ndim == 2:
+        vector_x2 = vector_x2[:, 0] if vector_x2.shape[1] == 1 else np.apply_along_axis(lambda x: np.abs(np.max(x) - np.sum(x)), 1, vector_x2)
+
+    return ranking_mi_numba_cmi.interaction_information_numba(
+        vector_y.astype(np.int32),
+        vector_x1.astype(np.int32),
+        vector_x2.astype(np.int32),
+        np.float32(mi_stratified_sampling_ratio),
+        cardinality_correction,
+    )
+
 
 def generate_data_for_ranking(combination: tuple[str, str], reference_model_features: list[str], args: Any, tmp_df: pd.DataFrame) -> tuple(np.ndarray, np.ndrray):
     feature_one, feature_two = combination
@@ -169,14 +213,14 @@ def generate_data_for_ranking(combination: tuple[str, str], reference_model_feat
         vector_first = tmp_df[feature_one].values
 
     vector_second = tmp_df[feature_two].values
-    
+
     # Ensure vectors have consistent shape to avoid repeated reshaping downstream
     # vector_first can be 1D or 2D (multi-column), vector_second is always 1D
     if vector_first.ndim == 1:
         vector_first = vector_first.reshape(-1, 1)
     if vector_second.ndim != 1:
         vector_second = vector_second.reshape(-1)
-    
+
     return vector_first, vector_second
 
 
@@ -196,7 +240,7 @@ def conduct_feature_ranking(vector_first: np.ndarray, vector_second: np.ndarray,
 
     elif heuristic == 'MI-numba-randomized':
         score = numba_mi(vector_first, vector_second, heuristic, args.mi_stratified_sampling_ratio)
-    
+
     elif heuristic == 'MI-numba-randomized-opt':
         score = numba_mi_opt(vector_first, vector_second, heuristic, args.mi_stratified_sampling_ratio)
 
@@ -211,7 +255,7 @@ def conduct_feature_ranking(vector_first: np.ndarray, vector_second: np.ndarray,
 
     elif heuristic == 'MI-multivalue-set':
         score = multivalue_mi_set_based(vector_first, vector_second)
-    
+
     elif heuristic == 'MI-multivalue-set-randomized':
         score = multivalue_mi_set_based(vector_first, vector_second, cardinality_correction=True)
 
@@ -279,8 +323,147 @@ def rank_features_3MR(
 
     return pd.DataFrame({'Feature': ranked_features, '3MR_Ranking': range(1, len(ranked_features) + 1)})
 
-def get_importances_estimate_nonmyopic(args: Any, tmp_df: pd.DataFrame):
-    pass
+def get_importances_estimate_nonmyopic(args: Any, tmp_df: pd.DataFrame, pairwise_mi_dict: dict | None = None, top_k: int = 50) -> pd.DataFrame | None:
+    """JMI greedy forward selection: selects features that maximize
+    sum of I(X_k; Y | X_j) over already-selected features X_j.
+
+    The Screening Rule: only considers top_k features by pairwise MI
+    to keep the O(top_k^2) CMI calls tractable.
+
+    Uses incremental score accumulation: when a new feature X_j is added
+    to the selected set, we only compute I(X_k; Y | X_j) for the new X_j
+    and add it to the running score. This reduces CMI calls from O(k^3)
+    to exactly k*(k-1)/2.
+    """
+    if not cmi_available:
+        logger.warning('CMI module not available, skipping nonmyopic ranking')
+        return None
+
+    label_col = args.label_column
+    if label_col not in tmp_df.columns:
+        logger.warning(f'Label column {label_col} not in dataframe, skipping JMI')
+        return None
+
+    feature_cols = [c for c in tmp_df.columns if c != label_col]
+    if len(feature_cols) == 0:
+        return None
+
+    # Screen to top-k by pairwise MI (exclude label from candidates)
+    if pairwise_mi_dict is not None:
+        feature_scores = {}
+        for (fa, fb), score in pairwise_mi_dict.items():
+            if fb == label_col and fa != label_col:
+                feature_scores[fa] = max(feature_scores.get(fa, -np.inf), score)
+            if fa == label_col and fb != label_col:
+                feature_scores[fb] = max(feature_scores.get(fb, -np.inf), score)
+        ranked = sorted(feature_scores.items(), key=lambda x: x[1], reverse=True)
+        candidate_features = [f for f, _ in ranked[:top_k] if f in tmp_df.columns]
+    else:
+        candidate_features = feature_cols[:top_k]
+
+    if len(candidate_features) == 0:
+        return None
+
+    Y = tmp_df[label_col].values.astype(np.int32)
+    cardinality_correction = 'randomized' in getattr(args, 'heuristic', '')
+    sampling_ratio = np.float32(getattr(args, 'mi_stratified_sampling_ratio', 1.0))
+
+    # Precompute encoded feature arrays
+    feature_arrays = {}
+    for f in candidate_features:
+        feature_arrays[f] = tmp_df[f].values.astype(np.int32)
+
+    # Greedy: first feature = highest pairwise MI with label
+    best_first = candidate_features[0]
+    selected = [best_first]
+    remaining = set(candidate_features) - {best_first}
+
+    # Running JMI scores: accumulate I(X_k; Y | X_j) incrementally.
+    # When X_j is newly selected, compute I(X_k; Y | X_j) for all remaining X_k
+    # and add to their running total. This avoids recomputing past contributions.
+    running_scores = {f: 0.0 for f in remaining}
+
+    # Initialize: compute I(X_k; Y | X_0) for all remaining X_k
+    for xk in remaining:
+        running_scores[xk] = float(
+            ranking_mi_numba_cmi.conditional_mutual_info_numba(
+                Y, feature_arrays[xk], feature_arrays[best_first],
+                sampling_ratio, cardinality_correction,
+            ),
+        )
+
+    while remaining and len(selected) < len(candidate_features):
+        # Pick the candidate with highest accumulated JMI score
+        best_feat = max(remaining, key=lambda f: running_scores[f])
+        selected.append(best_feat)
+        remaining.discard(best_feat)
+
+        if not remaining:
+            break
+
+        # Update running scores: add I(X_k; Y | X_{newly selected}) for all remaining
+        for xk in remaining:
+            cmi_val = float(
+                ranking_mi_numba_cmi.conditional_mutual_info_numba(
+                    Y, feature_arrays[xk], feature_arrays[best_feat],
+                    sampling_ratio, cardinality_correction,
+                ),
+            )
+            running_scores[xk] += cmi_val
+
+    return pd.DataFrame({'Feature': selected, 'JMI_Ranking': range(1, len(selected) + 1)})
+
+
+def compute_interaction_information_for_pairs(tmp_df: pd.DataFrame, args: Any, pairwise_mi_dict: dict | None = None, top_k: int = 30) -> pd.DataFrame | None:
+    """Compute II(X_i, X_j; Y) for all pairs among top-k features.
+
+    Negative II = synergy, Positive II = redundancy.
+    """
+    if not cmi_available:
+        logger.warning('CMI module not available, skipping interaction information')
+        return None
+
+    label_col = args.label_column
+    if label_col not in tmp_df.columns:
+        return None
+
+    feature_cols = [c for c in tmp_df.columns if c != label_col]
+
+    # Screen to top-k by pairwise MI (exclude label from candidates)
+    if pairwise_mi_dict is not None:
+        feature_scores = {}
+        for (fa, fb), score in pairwise_mi_dict.items():
+            if fb == label_col and fa != label_col:
+                feature_scores[fa] = max(feature_scores.get(fa, -np.inf), score)
+            if fa == label_col and fb != label_col:
+                feature_scores[fb] = max(feature_scores.get(fb, -np.inf), score)
+        ranked = sorted(feature_scores.items(), key=lambda x: x[1], reverse=True)
+        candidate_features = [f for f, _ in ranked[:top_k] if f in tmp_df.columns]
+    else:
+        candidate_features = feature_cols[:top_k]
+
+    if len(candidate_features) < 2:
+        return None
+
+    Y = tmp_df[label_col].values.astype(np.int32)
+    sampling_ratio = getattr(args, 'mi_stratified_sampling_ratio', 1.0)
+    cardinality_correction = 'randomized' in getattr(args, 'heuristic', '')
+
+    feature_arrays = {}
+    for f in candidate_features:
+        feature_arrays[f] = tmp_df[f].values.astype(np.int32)
+
+    rows = []
+    for i in range(len(candidate_features)):
+        for j in range(i + 1, len(candidate_features)):
+            fi, fj = candidate_features[i], candidate_features[j]
+            ii = ranking_mi_numba_cmi.interaction_information_numba(
+                Y, feature_arrays[fi], feature_arrays[fj],
+                np.float32(sampling_ratio), cardinality_correction,
+            )
+            rows.append((fi, fj, ii))
+
+    return pd.DataFrame(rows, columns=['FeatureA', 'FeatureB', 'InteractionInfo'])
 
 def initialize_classifier(surrogate_model: str, n_dim: int) -> Any:
 

--- a/outrank/algorithms/importance_estimator.py
+++ b/outrank/algorithms/importance_estimator.py
@@ -366,6 +366,9 @@ def get_importances_estimate_nonmyopic(args: Any, tmp_df: pd.DataFrame, pairwise
     if len(feature_cols) == 0:
         return None
 
+    # Clamp top_k to available features
+    top_k = min(top_k, len(feature_cols))
+
     # Screen to top-k by pairwise MI (exclude label from candidates)
     if pairwise_mi_dict is not None:
         feature_scores = {}
@@ -446,6 +449,9 @@ def compute_interaction_information_for_pairs(tmp_df: pd.DataFrame, args: Any, p
         return None
 
     feature_cols = [c for c in tmp_df.columns if c != label_col]
+
+    # Clamp top_k to available features
+    top_k = min(top_k, len(feature_cols))
 
     # Screen to top-k by pairwise MI (exclude label from candidates)
     if pairwise_mi_dict is not None:

--- a/outrank/cli_defaults.py
+++ b/outrank/cli_defaults.py
@@ -1,0 +1,43 @@
+"""Single source of truth for CLI/MCP default values.
+
+Both __main__.py (argparse) and mcp_adapters.py (Namespace builder)
+import from here to prevent silent divergence of defaults.
+"""
+from __future__ import annotations
+
+CLI_DEFAULTS: dict[str, object] = {
+    'task': 'all',
+    'minibatch_size': 2**14,
+    'output_folder': 'ranking_outputs',
+    'data_source': 'ob-vw',
+    'data_path': None,
+    'subsampling': 10,
+    'combination_number_upper_bound': 2**15,
+    'missing_value_symbols': ',{}',
+    'heuristic': 'MI-numba-randomized',
+    'include_noise_baseline_features': 'False',
+    'include_cardinality_in_feature_names': 'True',
+    'image_format': 'pdf',
+    'num_threads': 8,
+    'label_column': 'label',
+    'max_unique_hist_constraint': 30_000,
+    'transformers': 'none',
+    'rare_value_count_upper_bound': 1,
+    'feature_set_focus': None,
+    'interaction_order': 1,
+    'reference_model_JSON': '',
+    'target_ranking_only': 'True',
+    'explode_multivalue_features': 'False',
+    'subfeature_mapping': 'False',
+    'num_synthetic_features': 100,
+    'tldr': 'True',
+    'num_synthetic_rows': 1000000,
+    'generator_type': 'naive',
+    'output_synthetic_df_name': 'test_data_synthetic',
+    'disable_tqdm': 'False',
+    'mi_stratified_sampling_ratio': 1.0,
+    'compute_jmi': 'False',
+    'jmi_top_k': 50,
+    'compute_interaction_info': 'False',
+    'interaction_info_top_k': 30,
+}

--- a/outrank/core_ranking.py
+++ b/outrank/core_ranking.py
@@ -34,6 +34,7 @@ from outrank.core_utils import generic_line_parser
 from outrank.core_utils import get_num_of_instances
 from outrank.core_utils import internal_hash
 from outrank.core_utils import is_prior_heuristic
+from outrank.core_utils import MinibatchResult
 from outrank.core_utils import NominalFeatureSummary
 from outrank.core_utils import NumericFeatureSummary
 from outrank.feature_transformations.ranking_transformers import FeatureTransformerGeneric
@@ -592,7 +593,15 @@ def compute_batch_ranking(
 
 
 def get_grouped_df(importances_df_list: list[tuple[str, str, float]]) -> pd.DataFrame:
-    """A helper method that enables median-based aggregation after processing"""
+    """Median-based aggregation of per-batch importance triplets.
+
+    Note: median aggregation across minibatches is NOT the same as computing
+    MI on the pooled data. For features whose score distribution across
+    batches is long-tailed (e.g., a feature is informative in some data
+    segments but not others), median introduces a downward bias compared
+    to a single full-data MI estimate. This is a deliberate robustness
+    trade-off — median is resistant to outlier batches.
+    """
 
     importances_df = pd.DataFrame(importances_df_list, columns=['FeatureA', 'FeatureB', 'Score'])
     if importances_df.empty:
@@ -755,16 +764,16 @@ def estimate_importances_minibatches(
     local_pbar.set_description('Wrapping up')
     local_pbar.close()
 
-    return (
-        step_timing_checkpoints,
-        get_grouped_df(importances_df),
-        GLOBAL_CARDINALITY_STORAGE.copy(),
-        bounds_storage_batch,
-        memory_storage_batch,
-        local_coverage_object,
-        GLOBAL_RARE_VALUE_STORAGE.copy(),
-        GLOBAL_PRIOR_COMB_COUNTS.copy(),
-        GLOBAL_COUNTS_STORAGE.copy(),
-        last_jmi_ranking,
-        last_interaction_info,
+    return MinibatchResult(
+        step_timing_checkpoints=step_timing_checkpoints,
+        mutual_information_estimates=get_grouped_df(importances_df),
+        cardinality_object=GLOBAL_CARDINALITY_STORAGE.copy(),
+        bounds_object_storage=bounds_storage_batch,
+        memory_object_storage=memory_storage_batch,
+        coverage_object=local_coverage_object,
+        rare_value_storage=GLOBAL_RARE_VALUE_STORAGE.copy(),
+        prior_comb_counts=GLOBAL_PRIOR_COMB_COUNTS.copy(),
+        item_counts=GLOBAL_COUNTS_STORAGE.copy(),
+        jmi_ranking=last_jmi_ranking,
+        interaction_info=last_interaction_info,
     )

--- a/outrank/core_ranking.py
+++ b/outrank/core_ranking.py
@@ -424,9 +424,7 @@ def compute_feature_memory_consumption(input_dataframe: pd.DataFrame, args: Any)
     output_storage_features = defaultdict(set)
     n_rows = input_dataframe.shape[0]
     for col in input_dataframe.columns:
-        # np.char operations on object arrays are faster than pandas .str accessor
-        str_arr = input_dataframe[col].values.astype(str)
-        output_storage_features[col] = np.char.str_len(str_arr).sum() / n_rows
+        output_storage_features[col] = input_dataframe[col].astype(str).str.len().sum() / n_rows
     return output_storage_features
 
 

--- a/outrank/core_ranking.py
+++ b/outrank/core_ranking.py
@@ -109,13 +109,15 @@ def mixed_rank_graph(
     all_columns = input_dataframe.columns
 
     triplets = []
-    tmp_df = input_dataframe.copy().astype('category')
     out_time_struct = {}
 
     # Handle cont. types prior to interaction evaluation
     pbar.set_description('Encoding columns')
     start_enc_timer = timer()
-    tmp_df = pd.DataFrame({k : tmp_df[k].cat.codes for k in all_columns})
+    # pd.factorize is single-pass per column, avoids full .copy().astype('category')
+    tmp_df = pd.DataFrame(
+        {k: pd.factorize(input_dataframe[k])[0].astype(np.int32) for k in all_columns},
+    )
 
     end_enc_timer = timer()
     out_time_struct['encoding_columns'] = end_enc_timer - start_enc_timer
@@ -142,9 +144,14 @@ def mixed_rank_graph(
     # Map the scoring calls to the worker pool
     pbar.set_description('Allocating thread pool')
 
-    # starmap is an alternative that is slower unfortunately (but nicer)
+    # Pre-extract column arrays to avoid pickling the full DataFrame per worker.
+    # For reference_model heuristics we still need the DataFrame for multi-column access.
+    _col_arrays = {col: np.ascontiguousarray(tmp_df[col].values, dtype=np.int32) for col in tmp_df.columns}
+    _needs_df = bool(args.reference_model_JSON) or args.heuristic in {'surrogate-SGD', 'surrogate-SVM', 'surrogate-SGD-RP', 'surrogate-SGD-SVD'}
+    _tmp_df_for_workers = tmp_df if _needs_df else None
+
     def get_grounded_importances_estimate(combination: tuple[str]) -> Any:
-        return get_importances_estimate_pairwise(combination, reference_model_features, args, tmp_df=tmp_df)
+        return get_importances_estimate_pairwise(combination, reference_model_features, args, tmp_df=_tmp_df_for_workers, col_arrays=_col_arrays)
 
     start_enc_timer = timer()
     with cpu_pool as p:
@@ -402,17 +409,12 @@ def compute_coverage(input_dataframe: pd.DataFrame, args: Any) -> dict[str, set[
     """Compute coverage of features, incrementally"""
     output_storage_cov = defaultdict(set)
     all_missing_symbols = set(args.missing_value_symbols.split(','))
+    n_rows = input_dataframe.shape[0]
+    missing_arr = np.array(list(all_missing_symbols))
     for column in input_dataframe:
-        all_missing = sum(
-            [
-                input_dataframe[column].values.tolist().count(x)
-                for x in all_missing_symbols
-            ],
-        )
-
-        output_storage_cov[column] = (
-            1 - (all_missing / input_dataframe.shape[0])
-        ) * 100
+        col_vals = input_dataframe[column].values
+        all_missing = np.isin(col_vals, missing_arr).sum()
+        output_storage_cov[column] = (1 - (all_missing / n_rows)) * 100
 
     return output_storage_cov
 
@@ -420,15 +422,11 @@ def compute_coverage(input_dataframe: pd.DataFrame, args: Any) -> dict[str, set[
 def compute_feature_memory_consumption(input_dataframe: pd.DataFrame, args: Any) -> dict[str, set[str]]:
     """An approximation of how much feature take up"""
     output_storage_features = defaultdict(set)
+    n_rows = input_dataframe.shape[0]
     for col in input_dataframe.columns:
-        specific_column = [
-            str(x).strip() for x in input_dataframe[col].astype(str).values.tolist()
-        ]
-        col_size = sum(
-            len(x.encode())
-            for x in specific_column
-        ) / input_dataframe.shape[0]
-        output_storage_features[col] = col_size
+        # np.char operations on object arrays are faster than pandas .str accessor
+        str_arr = input_dataframe[col].values.astype(str)
+        output_storage_features[col] = np.char.str_len(str_arr).sum() / n_rows
     return output_storage_features
 
 
@@ -443,10 +441,11 @@ def compute_value_counts(input_dataframe: pd.DataFrame, args: Any):
     rare_value_count_upper_bound = args.rare_value_count_upper_bound
 
     for column in input_dataframe.columns:
-        main_values = input_dataframe[column].values
-        for value in main_values:
-            if value not in ignored_values:
-                global_storage[(column, value)] += 1
+        col_counts = Counter(input_dataframe[column].values.tolist())
+        for value, cnt in col_counts.items():
+            key = (column, value)
+            if key not in ignored_values:
+                global_storage[key] += cnt
 
     keys_to_remove = []
     for key, val in global_storage.items():
@@ -478,8 +477,7 @@ def compute_cardinalities(input_dataframe: pd.DataFrame, pbar: Any, max_unique_h
         if column not in GLOBAL_COUNTS_STORAGE:
             GLOBAL_COUNTS_STORAGE[column] = PrimitiveConstrainedCounter(max_unique_hist_constraint)
 
-        for value in column_data.values:
-            GLOBAL_COUNTS_STORAGE[column].add(value)
+        GLOBAL_COUNTS_STORAGE[column].batch_add(column_data.values.tolist())
 
         for unique_value in unique_values:
             if unique_value:

--- a/outrank/core_ranking.py
+++ b/outrank/core_ranking.py
@@ -19,6 +19,10 @@ import xxhash
 import zstandard as zstd
 
 from outrank.algorithms.importance_estimator import \
+    compute_interaction_information_for_pairs
+from outrank.algorithms.importance_estimator import \
+    get_importances_estimate_nonmyopic
+from outrank.algorithms.importance_estimator import \
     get_importances_estimate_pairwise
 from outrank.algorithms.sketches.counting_counters_ordinary import \
     PrimitiveConstrainedCounter
@@ -161,8 +165,30 @@ def mixed_rank_graph(
         final_triplets.append(inv)
         final_triplets.append(triplet)
 
+    # Optional JMI and interaction information (gated by CLI flags, default off)
+    jmi_ranking = None
+    interaction_info = None
+    pairwise_mi_dict = None
+
+    if getattr(args, 'compute_jmi', 'False') == 'True' or getattr(args, 'compute_interaction_info', 'False') == 'True':
+        pairwise_mi_dict = {(t[0], t[1]): t[2] for t in triplets}
+
+    if getattr(args, 'compute_jmi', 'False') == 'True':
+        pbar.set_description('Computing JMI ranking')
+        jmi_ranking = get_importances_estimate_nonmyopic(
+            args, tmp_df, pairwise_mi_dict=pairwise_mi_dict,
+            top_k=int(getattr(args, 'jmi_top_k', 50)),
+        )
+
+    if getattr(args, 'compute_interaction_info', 'False') == 'True':
+        pbar.set_description('Computing interaction information')
+        interaction_info = compute_interaction_information_for_pairs(
+            tmp_df, args, pairwise_mi_dict,
+            top_k=int(getattr(args, 'interaction_info_top_k', 30)),
+        )
+
     pbar.set_description('Proceeding to the next batch of data')
-    return BatchRankingSummary(final_triplets, out_time_struct)
+    return BatchRankingSummary(final_triplets, out_time_struct, jmi_ranking, interaction_info)
 
 
 def enrich_with_transformations(
@@ -616,6 +642,8 @@ def estimate_importances_minibatches(
     bounds_storage_batch = []
     memory_storage_batch = []
     step_timing_checkpoints = []
+    last_jmi_ranking = None
+    last_interaction_info = None
 
     local_coverage_object = defaultdict(list)
     local_pbar = tqdm.tqdm(
@@ -676,6 +704,11 @@ def estimate_importances_minibatches(
             step_timing_checkpoints.append(importances_batch.step_times)
             importances_df += importances_batch.triplet_scores
 
+            if importances_batch.jmi_ranking is not None:
+                last_jmi_ranking = importances_batch.jmi_ranking
+            if importances_batch.interaction_info is not None:
+                last_interaction_info = importances_batch.interaction_info
+
             if args.heuristic != 'Constant':
                 local_pbar.set_description('Creating checkpoint')
                 checkpoint_importances_df(importances_df)
@@ -718,6 +751,11 @@ def estimate_importances_minibatches(
         bounds_storage_batch.append(bounds_storage)
         checkpoint_importances_df(importances_df)
 
+        if importances_batch.jmi_ranking is not None:
+            last_jmi_ranking = importances_batch.jmi_ranking
+        if importances_batch.interaction_info is not None:
+            last_interaction_info = importances_batch.interaction_info
+
     local_pbar.set_description('Wrapping up')
     local_pbar.close()
 
@@ -731,4 +769,6 @@ def estimate_importances_minibatches(
         GLOBAL_RARE_VALUE_STORAGE.copy(),
         GLOBAL_PRIOR_COMB_COUNTS.copy(),
         GLOBAL_COUNTS_STORAGE.copy(),
+        last_jmi_ranking,
+        last_interaction_info,
     )

--- a/outrank/core_utils.py
+++ b/outrank/core_utils.py
@@ -85,6 +85,8 @@ class BatchRankingSummary:
 
     triplet_scores: list[tuple[str, str, float]]
     step_times: dict[str, Any]
+    jmi_ranking: Any = None
+    interaction_info: Any = None
 
 
 def display_random_tip() -> None:

--- a/outrank/core_utils.py
+++ b/outrank/core_utils.py
@@ -89,6 +89,27 @@ class BatchRankingSummary:
     interaction_info: Any = None
 
 
+@dataclass
+class MinibatchResult:
+    """Structured return type for estimate_importances_minibatches.
+
+    Replaces the 11-element positional tuple to make the return contract
+    explicit and reduce indexing errors at the call site.
+    """
+
+    step_timing_checkpoints: list[dict[str, Any]]
+    mutual_information_estimates: Any  # pd.DataFrame | None
+    cardinality_object: dict[Any, Any]
+    bounds_object_storage: list[dict[str, Any]]
+    memory_object_storage: list[dict[str, Any]]
+    coverage_object: Any  # defaultdict[str, list]
+    rare_value_storage: dict[str, Any]
+    prior_comb_counts: dict[Any, int]
+    item_counts: dict[str, Any]
+    jmi_ranking: Any = None  # pd.DataFrame | None
+    interaction_info: Any = None  # pd.DataFrame | None
+
+
 def display_random_tip() -> None:
     TIP_CONTENT = np.random.choice(pro_tips)
     tip_core = f"""

--- a/outrank/mcp_adapters.py
+++ b/outrank/mcp_adapters.py
@@ -1,0 +1,172 @@
+"""Adapter layer for the OutRank MCP server.
+
+Bridges MCP tool calls to OutRank internals:
+- Namespace builder (avoids importing __main__ argparse)
+- Logging redirect (stdout -> stderr, critical for stdio JSON-RPC)
+- SystemExit guard (task_ranking.py calls exit() in several places)
+- DataFrame -> JSON conversion
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from typing import Any
+
+
+def configure_logging_for_mcp() -> None:
+    """Redirect ALL logging output to stderr.
+
+    OutRank modules call logging.basicConfig() at import time
+    (__main__.py:13, task_ranking.py:24, core_utils.py:17,
+    task_generators.py:12). On stdio MCP transport, any stdout
+    output corrupts the JSON-RPC framing. This must be called
+    BEFORE importing any outrank module.
+    """
+    root = logging.getLogger()
+    # Remove any existing handlers (including stdout ones
+    # that basicConfig may have installed)
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+    # Install a single stderr handler
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setFormatter(
+        logging.Formatter('%(asctime)s - %(name)s - %(message)s'),
+    )
+    root.addHandler(stderr_handler)
+    root.setLevel(logging.INFO)
+
+    # Monkey-patch basicConfig to be a no-op so subsequent OutRank
+    # imports don't re-add stdout handlers.
+    logging.basicConfig = lambda **kwargs: None  # type: ignore[assignment]
+
+
+def build_ranking_namespace(**overrides: Any) -> argparse.Namespace:
+    """Build an argparse.Namespace matching all CLI flags.
+
+    Defaults are hardcoded here (mirrored from __main__.py) to avoid
+    importing __main__ and triggering its logging.basicConfig().
+    """
+    defaults = {
+        'task': 'ranking',
+        'minibatch_size': 2**14,
+        'output_folder': '/tmp/outrank_mcp_output',
+        'data_source': 'csv-raw',
+        'data_path': None,
+        'subsampling': 10,
+        'combination_number_upper_bound': 2**15,
+        'missing_value_symbols': ',{}',
+        'heuristic': 'MI-numba-randomized',
+        'include_noise_baseline_features': 'False',
+        'include_cardinality_in_feature_names': 'True',
+        'image_format': 'pdf',
+        'num_threads': 4,
+        'label_column': 'label',
+        'max_unique_hist_constraint': 30_000,
+        'transformers': 'none',
+        'rare_value_count_upper_bound': 1,
+        'feature_set_focus': None,
+        'interaction_order': 1,
+        'reference_model_JSON': '',
+        'target_ranking_only': 'True',
+        'explode_multivalue_features': 'False',
+        'subfeature_mapping': 'False',
+        'num_synthetic_features': 100,
+        'tldr': 'False',
+        'num_synthetic_rows': 10000,
+        'generator_type': 'naive',
+        'output_synthetic_df_name': 'test_data_synthetic',
+        'disable_tqdm': 'True',  # Always suppress in MCP context
+        'mi_stratified_sampling_ratio': 1.0,
+        'compute_jmi': 'False',
+        'jmi_top_k': 50,
+        'compute_interaction_info': 'False',
+        'interaction_info_top_k': 30,
+    }
+    # Apply caller overrides, converting Python bools to OutRank string convention
+    for key, value in overrides.items():
+        if isinstance(value, bool):
+            value = 'True' if value else 'False'
+        defaults[key] = value
+
+    return argparse.Namespace(**defaults)
+
+
+def run_ranking_safe(args: argparse.Namespace) -> dict[str, Any]:
+    """Run outrank_task_conduct_ranking with SystemExit protection.
+
+    task_ranking.py calls exit() at lines 130, 139, 163.
+    os.remove('ranking_checkpoint_tmp.tsv') at line 317 may fail.
+    Returns a dict with parsed output files.
+    """
+    import time
+
+    from outrank.task_ranking import outrank_task_conduct_ranking
+
+    start = time.monotonic()
+    error_msg = None
+    try:
+        outrank_task_conduct_ranking(args)
+    except SystemExit:
+        # Lines 130, 139, 163 — non-fatal for our purposes
+        pass
+    except Exception as exc:
+        error_msg = f'{type(exc).__name__}: {exc}'
+        logging.getLogger('outrank.mcp').warning(
+            'Ranking failed: %s', error_msg,
+        )
+    elapsed = time.monotonic() - start
+
+    result: dict[str, Any] = {
+        'output_folder': args.output_folder,
+        'elapsed_seconds': round(elapsed, 2),
+    }
+    if error_msg is not None:
+        result['error'] = error_msg
+
+    # Read back pairwise ranks if they were written
+    pairwise_path = os.path.join(args.output_folder, 'pairwise_ranks.tsv')
+    if os.path.exists(pairwise_path):
+        import pandas as pd
+        df = pd.read_csv(pairwise_path, sep='\t')
+        result['pairwise_ranks'] = dataframe_to_ranking_json(df)
+
+    # JMI results
+    jmi_path = os.path.join(args.output_folder, 'jmi_feature_ranking.tsv')
+    if os.path.exists(jmi_path):
+        import pandas as pd
+        df = pd.read_csv(jmi_path, sep='\t')
+        result['jmi_ranking'] = df.to_dict(orient='records')
+
+    # Interaction information
+    ii_path = os.path.join(args.output_folder, 'interaction_information.tsv')
+    if os.path.exists(ii_path):
+        import pandas as pd
+        df = pd.read_csv(ii_path, sep='\t')
+        result['interaction_info'] = df.to_dict(orient='records')
+
+    # Timings
+    timings_path = os.path.join(args.output_folder, 'timings.json')
+    if os.path.exists(timings_path):
+        import json
+        with open(timings_path) as f:
+            result['timings'] = json.load(f)
+
+    return result
+
+
+def dataframe_to_ranking_json(
+    df: Any, top_n: int | None = None,
+) -> list[dict[str, Any]]:
+    """Convert a pairwise_ranks DataFrame to JSON-serializable list."""
+    if top_n is not None:
+        df = df.head(top_n)
+    records = []
+    for _, row in df.iterrows():
+        records.append({
+            'feature_a': str(row.iloc[0]),
+            'feature_b': str(row.iloc[1]),
+            'score': float(row.iloc[2]),
+        })
+    return records

--- a/outrank/mcp_adapters.py
+++ b/outrank/mcp_adapters.py
@@ -15,6 +15,9 @@ import sys
 from typing import Any
 
 
+MAX_FILE_SIZE_MB = 500
+
+
 def configure_logging_for_mcp() -> None:
     """Redirect ALL logging output to stderr.
 
@@ -45,45 +48,20 @@ def configure_logging_for_mcp() -> None:
 def build_ranking_namespace(**overrides: Any) -> argparse.Namespace:
     """Build an argparse.Namespace matching all CLI flags.
 
-    Defaults are hardcoded here (mirrored from __main__.py) to avoid
-    importing __main__ and triggering its logging.basicConfig().
+    Defaults come from cli_defaults.py (single source of truth),
+    with MCP-specific overrides applied on top.
     """
-    defaults = {
-        'task': 'ranking',
-        'minibatch_size': 2**14,
-        'output_folder': '/tmp/outrank_mcp_output',
-        'data_source': 'csv-raw',
-        'data_path': None,
-        'subsampling': 10,
-        'combination_number_upper_bound': 2**15,
-        'missing_value_symbols': ',{}',
-        'heuristic': 'MI-numba-randomized',
-        'include_noise_baseline_features': 'False',
-        'include_cardinality_in_feature_names': 'True',
-        'image_format': 'pdf',
-        'num_threads': 4,
-        'label_column': 'label',
-        'max_unique_hist_constraint': 30_000,
-        'transformers': 'none',
-        'rare_value_count_upper_bound': 1,
-        'feature_set_focus': None,
-        'interaction_order': 1,
-        'reference_model_JSON': '',
-        'target_ranking_only': 'True',
-        'explode_multivalue_features': 'False',
-        'subfeature_mapping': 'False',
-        'num_synthetic_features': 100,
-        'tldr': 'False',
-        'num_synthetic_rows': 10000,
-        'generator_type': 'naive',
-        'output_synthetic_df_name': 'test_data_synthetic',
-        'disable_tqdm': 'True',  # Always suppress in MCP context
-        'mi_stratified_sampling_ratio': 1.0,
-        'compute_jmi': 'False',
-        'jmi_top_k': 50,
-        'compute_interaction_info': 'False',
-        'interaction_info_top_k': 30,
-    }
+    from outrank.cli_defaults import CLI_DEFAULTS
+
+    defaults = dict(CLI_DEFAULTS)
+    # MCP-specific overrides: headless mode
+    defaults['task'] = 'ranking'
+    defaults['output_folder'] = '/tmp/outrank_mcp_output'
+    defaults['data_source'] = 'csv-raw'
+    defaults['num_threads'] = 4
+    defaults['disable_tqdm'] = 'True'
+    defaults['tldr'] = 'False'
+    defaults['num_synthetic_rows'] = 10000
     # Apply caller overrides, converting Python bools to OutRank string convention
     for key, value in overrides.items():
         if isinstance(value, bool):
@@ -91,6 +69,30 @@ def build_ranking_namespace(**overrides: Any) -> argparse.Namespace:
         defaults[key] = value
 
     return argparse.Namespace(**defaults)
+
+
+def validate_data_path(data_path: str | None) -> None:
+    """Validate data_path exists and is accessible. Raises ValueError on failure."""
+    if data_path is None:
+        raise ValueError('data_path must not be None')
+    if not os.path.exists(data_path):
+        raise ValueError(f"data_path '{data_path}' does not exist")
+    if os.path.isfile(data_path):
+        size_mb = os.path.getsize(data_path) / (1024 * 1024)
+        if size_mb > MAX_FILE_SIZE_MB:
+            raise ValueError(
+                f"File '{data_path}' is {size_mb:.0f} MB, "
+                f'exceeding the {MAX_FILE_SIZE_MB} MB limit',
+            )
+    elif os.path.isdir(data_path):
+        csv_path = os.path.join(data_path, 'data.csv')
+        if os.path.isfile(csv_path):
+            size_mb = os.path.getsize(csv_path) / (1024 * 1024)
+            if size_mb > MAX_FILE_SIZE_MB:
+                raise ValueError(
+                    f"File '{csv_path}' is {size_mb:.0f} MB, "
+                    f'exceeding the {MAX_FILE_SIZE_MB} MB limit',
+                )
 
 
 def run_ranking_safe(args: argparse.Namespace) -> dict[str, Any]:
@@ -103,6 +105,16 @@ def run_ranking_safe(args: argparse.Namespace) -> dict[str, Any]:
     import time
 
     from outrank.task_ranking import outrank_task_conduct_ranking
+
+    # Validate inputs before launching the ranking pipeline
+    try:
+        validate_data_path(args.data_path)
+    except ValueError as exc:
+        return {
+            'output_folder': args.output_folder,
+            'elapsed_seconds': 0,
+            'error': str(exc),
+        }
 
     start = time.monotonic()
     error_msg = None

--- a/outrank/mcp_server.py
+++ b/outrank/mcp_server.py
@@ -27,6 +27,7 @@ from outrank.mcp_adapters import (
     build_ranking_namespace,
     dataframe_to_ranking_json,
     run_ranking_safe,
+    validate_data_path,
 )
 
 logger = logging.getLogger('outrank.mcp')
@@ -238,6 +239,7 @@ def outrank_dataset_info(
         data_source: Data source format. Use "csv-raw" for plain CSV files.
         sample_rows: Number of sample rows to include in the response.
     """
+    validate_data_path(data_path)
     csv_path = _resolve_csv_path(data_path, data_source)
     df = pd.read_csv(csv_path, nrows=sample_rows + 1)
     df_full_shape = pd.read_csv(csv_path, usecols=[0])
@@ -340,6 +342,7 @@ def outrank_score_pair(
     """
     from outrank.algorithms.importance_estimator import conduct_feature_ranking
 
+    validate_data_path(data_path)
     csv_path = _resolve_csv_path(data_path, data_source)
     df = pd.read_csv(csv_path, usecols=[feature_a, feature_b])
     if subsampling > 1:
@@ -395,6 +398,7 @@ def outrank_compute_interaction_info(
     """
     from outrank.algorithms.feature_ranking import ranking_mi_numba_cmi
 
+    validate_data_path(data_path)
     csv_path = _resolve_csv_path(data_path, data_source)
     df = pd.read_csv(csv_path, usecols=[feature_a, feature_b, label_column])
 

--- a/outrank/mcp_server.py
+++ b/outrank/mcp_server.py
@@ -1,0 +1,558 @@
+"""OutRank MCP Server — exposes feature ranking as callable tools.
+
+Transport: stdio (standard for Claude Code).
+Start:     python -m outrank.mcp_server
+
+CRITICAL: configure_logging_for_mcp() MUST run before any outrank import
+to prevent stdout pollution that would corrupt JSON-RPC framing.
+"""
+from __future__ import annotations
+
+from outrank.mcp_adapters import configure_logging_for_mcp
+# --- Logging redirect (MUST be first) ---
+configure_logging_for_mcp()
+
+import json
+import logging
+import os
+import sys
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from mcp.server.fastmcp import FastMCP
+
+from outrank.mcp_adapters import (
+    build_ranking_namespace,
+    dataframe_to_ranking_json,
+    run_ranking_safe,
+)
+
+logger = logging.getLogger('outrank.mcp')
+
+# ---------------------------------------------------------------------------
+# Server instance
+# ---------------------------------------------------------------------------
+mcp = FastMCP(
+    'outrank',
+    instructions='OutRank: fast feature ranking for sparse data sets. '
+    'Provides mutual-information-based feature scoring, '
+    'JMI greedy selection, interaction information, '
+    'and synthetic data generation.',
+)
+
+# ---------------------------------------------------------------------------
+# Heuristic registry (static, no computation)
+# ---------------------------------------------------------------------------
+HEURISTICS = [
+    {
+        'name': 'MI-numba-randomized',
+        'description': 'Mutual information with cardinality correction (Numba JIT). '
+        'Prevents high-cardinality features from inflating scores.',
+        'speed': 'fast',
+        'recommended_for': 'Default choice. Best balance of speed and accuracy.',
+    },
+    {
+        'name': 'MI-numba-randomized-opt',
+        'description': 'Optimized MI-numba variant with identical semantics but faster inner loop.',
+        'speed': 'fast',
+        'recommended_for': 'Same as MI-numba-randomized; slightly faster on large cardinalities.',
+    },
+    {
+        'name': 'MI',
+        'description': 'Mutual information via sklearn (mutual_info_classif). No cardinality correction.',
+        'speed': 'moderate',
+        'recommended_for': 'Baseline comparison or when Numba is unavailable.',
+    },
+    {
+        'name': 'AMI',
+        'description': 'Adjusted mutual information (sklearn). Corrects for chance agreement.',
+        'speed': 'moderate',
+        'recommended_for': 'When features have very different cardinalities and you want chance-corrected scores.',
+    },
+    {
+        'name': 'correlation-Pearson',
+        'description': 'Pearson correlation coefficient. Linear relationships only.',
+        'speed': 'fast',
+        'recommended_for': 'Numeric features with suspected linear relationship to label.',
+    },
+    {
+        'name': 'surrogate-SGD',
+        'description': 'SGD logistic regression surrogate. Cross-validated log-loss.',
+        'speed': 'slow',
+        'recommended_for': 'When you want model-based feature importance (linear).',
+    },
+    {
+        'name': 'surrogate-SGD-SVD',
+        'description': 'SGD with SVD dimensionality reduction. Handles high-cardinality OHE.',
+        'speed': 'slow',
+        'recommended_for': 'High-cardinality features where full OHE is too wide.',
+    },
+    {
+        'name': 'surrogate-SGD-RP',
+        'description': 'SGD with random projection. Faster than SVD for very wide features.',
+        'speed': 'slow',
+        'recommended_for': 'Very high-cardinality features.',
+    },
+    {
+        'name': 'surrogate-SVM',
+        'description': 'SVM surrogate with RBF kernel. Cross-validated log-loss.',
+        'speed': 'very slow',
+        'recommended_for': 'Non-linear feature importance (small datasets only).',
+    },
+    {
+        'name': 'max-value-coverage',
+        'description': 'Coverage alignment heuristic. Scores by value co-occurrence.',
+        'speed': 'fast',
+        'recommended_for': 'Exploratory analysis of feature coverage patterns.',
+    },
+    {
+        'name': 'MI-multivalue-jaccard',
+        'description': 'MI for semicolon-separated multivalue features using Jaccard similarity.',
+        'speed': 'moderate',
+        'recommended_for': 'Multivalue features (e.g., tags, categories) with Jaccard distance.',
+    },
+    {
+        'name': 'MI-multivalue-overlap',
+        'description': 'MI for multivalue features using overlap coefficient.',
+        'speed': 'moderate',
+        'recommended_for': 'Multivalue features where subset relationships matter.',
+    },
+    {
+        'name': 'MI-multivalue-set',
+        'description': 'MI for multivalue features using set-based encoding.',
+        'speed': 'moderate',
+        'recommended_for': 'Multivalue features with set-based similarity.',
+    },
+    {
+        'name': 'MI-multivalue-set-randomized',
+        'description': 'Set-based MI with cardinality correction for multivalue features.',
+        'speed': 'moderate',
+        'recommended_for': 'Multivalue features where cardinality varies widely.',
+    },
+    {
+        'name': 'Constant',
+        'description': 'Returns 0.0 for all pairs. Used internally for rare-value and transformer tasks.',
+        'speed': 'instant',
+        'recommended_for': 'Internal use only (feature_summary_transformers, identify_rare_values).',
+    },
+]
+
+USAGE_GUIDE = """\
+# OutRank MCP Usage Guide
+
+## Data Format
+OutRank expects CSV files with a header row. The label/target column
+defaults to "label" but can be set via `label_column`.
+
+For `data_source="csv-raw"`, provide the path to a directory containing
+a single `data.csv` file, or point `data_path` directly at a `.csv` file.
+
+## Common Workflows
+
+### 1. Quick feature ranking (target-only)
+Use `outrank_rank_features` with `target_ranking_only=True` (default).
+This scores each feature against the label — O(n) pairs, fast.
+
+### 2. Full pairwise ranking
+Set `target_ranking_only=False` to score all feature pairs — O(n^2).
+Use `subsampling` to control speed vs. accuracy.
+
+### 3. Synergy detection
+Enable `compute_jmi=True` for JMI greedy selection (finds XOR-like
+synergies) and/or `compute_interaction_info=True` for pairwise
+interaction information (negative = synergy, positive = redundancy).
+
+### 4. Quick pair check
+Use `outrank_score_pair` to score two specific features without
+running the full pipeline.
+
+### 5. Dataset inspection
+Use `outrank_dataset_info` before ranking to verify column names,
+cardinalities, and data shape.
+
+## Heuristic Selection
+- **MI-numba-randomized** (default): Fast, accurate, handles cardinality.
+- **MI**: Sklearn baseline, no cardinality correction.
+- **surrogate-***: Model-based importance. Slower but captures non-linear signal.
+- **MI-multivalue-***: For semicolon-separated multivalue features.
+
+## Performance Tips
+- `subsampling=100` → 10x faster, usually sufficient for ranking order.
+- `num_threads=8` → Good default for most machines.
+- `target_ranking_only=True` → O(n) instead of O(n^2).
+- `combination_number_upper_bound` → Caps pairs per batch (Monte Carlo sampling).
+
+## Gotchas
+- Boolean flags use string values: `"True"` / `"False"` (not Python bools).
+  The MCP tools handle this conversion automatically.
+- The label column must exist in the data.
+- For `csv-raw` data_source, `data_path` should point to a directory
+  containing `data.csv`, or to a csv file directly.
+"""
+
+# ---------------------------------------------------------------------------
+# Resources
+# ---------------------------------------------------------------------------
+
+@mcp.resource('outrank://heuristics')
+def resource_heuristics() -> str:
+    """List of all available scoring heuristics with descriptions."""
+    return json.dumps(HEURISTICS, indent=2)
+
+
+@mcp.resource('outrank://guide')
+def resource_guide() -> str:
+    """Condensed usage guide for agents — data formats, workflows, gotchas."""
+    return USAGE_GUIDE
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool()
+def outrank_list_heuristics() -> str:
+    """List all available scoring heuristics with descriptions, speed ratings, and recommendations.
+
+    No parameters needed. Returns a JSON array of heuristic objects.
+    """
+    return json.dumps(HEURISTICS, indent=2)
+
+
+@mcp.tool()
+def outrank_dataset_info(
+    data_path: str,
+    data_source: str = 'csv-raw',
+    sample_rows: int = 5,
+) -> str:
+    """Inspect a dataset's structure before ranking.
+
+    Returns column names, row count, cardinalities, and a sample of data.
+    Use this to verify the dataset is correctly formatted before running
+    a full ranking.
+
+    Args:
+        data_path: Path to the data directory or CSV file.
+        data_source: Data source format. Use "csv-raw" for plain CSV files.
+        sample_rows: Number of sample rows to include in the response.
+    """
+    csv_path = _resolve_csv_path(data_path, data_source)
+    df = pd.read_csv(csv_path, nrows=sample_rows + 1)
+    df_full_shape = pd.read_csv(csv_path, usecols=[0])
+    num_rows = len(df_full_shape)
+
+    # Re-read sample with all columns
+    df_sample = pd.read_csv(csv_path, nrows=sample_rows)
+    cardinalities = {}
+    # Read more rows for cardinality estimation
+    df_card = pd.read_csv(csv_path, nrows=min(10000, num_rows))
+    for col in df_card.columns:
+        cardinalities[col] = int(df_card[col].nunique())
+
+    result = {
+        'columns': list(df_sample.columns),
+        'num_rows': num_rows,
+        'num_columns': len(df_sample.columns),
+        'column_cardinalities': cardinalities,
+        'sample_data': df_sample.to_dict(orient='records'),
+    }
+    return json.dumps(result, indent=2, default=str)
+
+
+@mcp.tool()
+def outrank_rank_features(
+    data_path: str,
+    label_column: str = 'label',
+    heuristic: str = 'MI-numba-randomized',
+    data_source: str = 'csv-raw',
+    target_ranking_only: bool = True,
+    subsampling: int = 10,
+    num_threads: int = 4,
+    compute_jmi: bool = False,
+    jmi_top_k: int = 50,
+    compute_interaction_info: bool = False,
+    interaction_info_top_k: int = 30,
+    output_folder: str = '/tmp/outrank_mcp_output',
+) -> str:
+    """Run the full OutRank feature ranking pipeline on a dataset.
+
+    This is the primary tool. It scores features against a label column
+    using mutual-information-based heuristics. Optionally computes JMI
+    (Joint Mutual Information) greedy selection and interaction information.
+
+    Args:
+        data_path: Path to the data directory containing data.csv, or path to a CSV file.
+        label_column: Name of the target/label column.
+        heuristic: Scoring heuristic. Use outrank_list_heuristics to see all options.
+        data_source: Data source format. Use "csv-raw" for plain CSV.
+        target_ranking_only: If True, only score features vs label (fast, O(n)). If False, score all pairs (O(n^2)).
+        subsampling: Subsample ratio — every n-th instance. Higher = faster but less precise.
+        num_threads: Number of parallel threads.
+        compute_jmi: If True, run JMI greedy selection after pairwise ranking. Detects synergies.
+        jmi_top_k: Number of top features to consider for JMI.
+        compute_interaction_info: If True, compute interaction information for top feature pairs.
+        interaction_info_top_k: Number of top features for interaction info computation.
+        output_folder: Where to write output files.
+    """
+    args = build_ranking_namespace(
+        data_path=data_path,
+        label_column=label_column,
+        heuristic=heuristic,
+        data_source=data_source,
+        target_ranking_only=target_ranking_only,
+        subsampling=subsampling,
+        num_threads=num_threads,
+        compute_jmi=compute_jmi,
+        jmi_top_k=jmi_top_k,
+        compute_interaction_info=compute_interaction_info,
+        interaction_info_top_k=interaction_info_top_k,
+        output_folder=output_folder,
+    )
+    result = run_ranking_safe(args)
+    return json.dumps(result, indent=2, default=str)
+
+
+@mcp.tool()
+def outrank_score_pair(
+    data_path: str,
+    feature_a: str,
+    feature_b: str,
+    heuristic: str = 'MI-numba-randomized',
+    data_source: str = 'csv-raw',
+    label_column: str = 'label',
+    subsampling: int = 1,
+) -> str:
+    """Score two specific features without running the full pipeline.
+
+    Reads the CSV directly, encodes the two columns, and computes the
+    pairwise score. Much faster than outrank_rank_features for quick checks.
+
+    Args:
+        data_path: Path to the data directory or CSV file.
+        feature_a: Name of the first feature column.
+        feature_b: Name of the second feature column (often the label).
+        heuristic: Scoring heuristic to use.
+        data_source: Data source format.
+        label_column: Name of the label column (used for args construction).
+        subsampling: Subsample ratio. 1 = use all rows.
+    """
+    from outrank.algorithms.importance_estimator import conduct_feature_ranking
+
+    csv_path = _resolve_csv_path(data_path, data_source)
+    df = pd.read_csv(csv_path, usecols=[feature_a, feature_b])
+    if subsampling > 1:
+        df = df.iloc[::subsampling]
+
+    v1, _ = pd.factorize(df[feature_a])
+    v2, _ = pd.factorize(df[feature_b])
+
+    v1 = v1.astype(np.int32)
+    v2 = v2.astype(np.int32)
+
+    args = build_ranking_namespace(
+        heuristic=heuristic,
+        label_column=label_column,
+        mi_stratified_sampling_ratio=1.0,
+    )
+    score = conduct_feature_ranking(v1, v2, args)
+
+    result = {
+        'feature_a': feature_a,
+        'feature_b': feature_b,
+        'score': float(score),
+        'heuristic': heuristic,
+        'n_samples': len(df),
+    }
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+def outrank_compute_interaction_info(
+    data_path: str,
+    feature_a: str,
+    feature_b: str,
+    label_column: str = 'label',
+    data_source: str = 'csv-raw',
+    cardinality_correction: bool = False,
+) -> str:
+    """Compute interaction information II(feature_a, feature_b; label).
+
+    Measures synergy vs. redundancy between two features with respect to the label.
+    Uses the Jakulin & Bratko convention: negative = synergy, positive = redundancy.
+
+    Synergy means the features are more informative together than separately.
+    Redundancy means they carry overlapping information about the label.
+
+    Args:
+        data_path: Path to the data directory or CSV file.
+        feature_a: First feature column name.
+        feature_b: Second feature column name.
+        label_column: Target/label column name.
+        data_source: Data source format.
+        cardinality_correction: Apply cardinality correction to MI estimates.
+    """
+    from outrank.algorithms.feature_ranking import ranking_mi_numba_cmi
+
+    csv_path = _resolve_csv_path(data_path, data_source)
+    df = pd.read_csv(csv_path, usecols=[feature_a, feature_b, label_column])
+
+    y, _ = pd.factorize(df[label_column])
+    x1, _ = pd.factorize(df[feature_a])
+    x2, _ = pd.factorize(df[feature_b])
+
+    y = y.astype(np.int32)
+    x1 = x1.astype(np.int32)
+    x2 = x2.astype(np.int32)
+
+    ii = float(
+        ranking_mi_numba_cmi.interaction_information_numba(
+            y, x1, x2, np.float32(1.0), cardinality_correction,
+        ),
+    )
+
+    if ii < -0.01:
+        interpretation = 'synergy (features are more informative together than separately)'
+    elif ii > 0.01:
+        interpretation = 'redundancy (features carry overlapping information about the label)'
+    else:
+        interpretation = 'near-zero (features contribute roughly independently)'
+
+    result = {
+        'feature_a': feature_a,
+        'feature_b': feature_b,
+        'interaction_info': ii,
+        'interpretation': interpretation,
+        'convention': 'Jakulin & Bratko (negative=synergy, positive=redundancy)',
+    }
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+def outrank_generate_synthetic_data(
+    output_path: str = '/tmp/outrank_synthetic',
+    num_features: int = 100,
+    num_rows: int = 10000,
+    generator_type: str = 'naive',
+) -> str:
+    """Generate a synthetic dataset for testing OutRank.
+
+    Creates a CSV with the specified number of features and rows,
+    including a "label" column. Useful for testing ranking workflows
+    without requiring real data.
+
+    Args:
+        output_path: Directory to write the generated data.csv.
+        num_features: Number of features to generate.
+        num_rows: Number of rows to generate.
+        generator_type: Generator type. Currently only "naive" is supported.
+    """
+    from outrank.algorithms.synthetic_data_generators import generator_naive
+
+    if generator_type != 'naive':
+        return json.dumps({'error': f'Generator {generator_type} not implemented.'})
+
+    # Call generator directly to avoid task_generators.py's `./` path prefix bug
+    sample, target = generator_naive.generate_random_matrix(num_features, num_rows)
+    df = pd.DataFrame(sample, columns=[f'f{i}' for i in range(num_features)])
+    df['label'] = target
+
+    os.makedirs(output_path, exist_ok=True)
+    df.to_csv(os.path.join(output_path, 'data.csv'), index=False)
+
+    csv_path = os.path.join(output_path, 'data.csv')
+    actual_shape = None
+    if os.path.exists(csv_path):
+        df = pd.read_csv(csv_path, nrows=1)
+        # Get row count cheaply
+        with open(csv_path) as f:
+            actual_rows = sum(1 for _ in f) - 1  # minus header
+        actual_shape = {'rows': actual_rows, 'columns': len(df.columns)}
+
+    result = {
+        'output_path': output_path,
+        'csv_file': csv_path,
+        'requested': {'num_features': num_features, 'num_rows': num_rows},
+        'actual_shape': actual_shape,
+    }
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+def outrank_summarize_results(
+    output_folder: str,
+    top_n: int = 20,
+) -> str:
+    """Read and summarize ranking output from a previous OutRank run.
+
+    Parses pairwise_ranks.tsv and returns the top-N features sorted by score.
+    Also includes JMI and interaction info results if available.
+
+    Args:
+        output_folder: Path to the OutRank output folder (containing pairwise_ranks.tsv).
+        top_n: Number of top results to return.
+    """
+    result: dict[str, Any] = {}
+
+    pairwise_path = os.path.join(output_folder, 'pairwise_ranks.tsv')
+    if os.path.exists(pairwise_path):
+        df = pd.read_csv(pairwise_path, sep='\t')
+        df = df.sort_values(by=df.columns[2], ascending=False)
+        top = df.head(top_n)
+        result['top_pairwise_ranks'] = dataframe_to_ranking_json(top)
+
+        # Build markdown table
+        lines = ['| Rank | Feature A | Feature B | Score |', '|------|-----------|-----------|-------|']
+        for i, (_, row) in enumerate(top.iterrows(), 1):
+            lines.append(f'| {i} | {row.iloc[0]} | {row.iloc[1]} | {row.iloc[2]:.6f} |')
+        result['markdown_table'] = '\n'.join(lines)
+    else:
+        result['error'] = f'pairwise_ranks.tsv not found in {output_folder}'
+
+    jmi_path = os.path.join(output_folder, 'jmi_feature_ranking.tsv')
+    if os.path.exists(jmi_path):
+        jmi_df = pd.read_csv(jmi_path, sep='\t')
+        result['jmi_ranking'] = jmi_df.to_dict(orient='records')
+
+    ii_path = os.path.join(output_folder, 'interaction_information.tsv')
+    if os.path.exists(ii_path):
+        ii_df = pd.read_csv(ii_path, sep='\t')
+        ii_df = ii_df.sort_values(by='InteractionInfo')
+        result['interaction_info'] = ii_df.head(top_n).to_dict(orient='records')
+
+    return json.dumps(result, indent=2, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_csv_path(data_path: str, data_source: str) -> str:
+    """Resolve a data_path to the actual CSV file path.
+
+    For csv-raw, data_path may be:
+    - A directory containing data.csv
+    - A direct path to a .csv file
+    """
+    if os.path.isfile(data_path) and data_path.endswith('.csv'):
+        return data_path
+    csv_in_dir = os.path.join(data_path, 'data.csv')
+    if os.path.isfile(csv_in_dir):
+        return csv_in_dir
+    raise FileNotFoundError(
+        f'Could not find CSV data at {data_path}. '
+        f'Expected a .csv file or a directory containing data.csv.',
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    mcp.run(transport='stdio')
+
+
+if __name__ == '__main__':
+    main()

--- a/outrank/task_ranking.py
+++ b/outrank/task_ranking.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import gzip
 import json
 import logging
 import os
@@ -9,7 +10,6 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-import gzip
 import zstandard as zstd
 
 from outrank.algorithms.importance_estimator import rank_features_3MR
@@ -103,6 +103,8 @@ def outrank_task_conduct_ranking(args: Any) -> None:
                     RARE_VALUE_STORAGE,
                     GLOBAL_PRIOR_COMB_COUNTS,
                     GLOBAL_ITEM_COUNTS,
+                    jmi_ranking_result,
+                    interaction_info_result,
                 ) = estimate_importances_minibatches(**cmd_arguments)
 
             global_bounds_storage += bounds_object_storage
@@ -295,6 +297,18 @@ def outrank_task_conduct_ranking(args: Any) -> None:
     dfx = pd.DataFrame(all_timings)
     dfx.to_json(f'{args.output_folder}/timings.json')
     write_json_dump_to_file(args, f'{args.output_folder}/arguments.json')
+
+    # Write JMI rankings (last batch — JMI is deterministic per encoded batch)
+    if jmi_ranking_result is not None:
+        jmi_path = os.path.join(args.output_folder, 'jmi_feature_ranking.tsv')
+        jmi_ranking_result.to_csv(jmi_path, sep='\t', index=False)
+        logging.info(f'JMI feature ranking written to {jmi_path}')
+
+    # Write interaction information
+    if interaction_info_result is not None:
+        ii_path = os.path.join(args.output_folder, 'interaction_information.tsv')
+        interaction_info_result.to_csv(ii_path, sep='\t', index=False)
+        logging.info(f'Interaction information written to {ii_path}')
 
     logging.info(
         f'Finished with ranking! Result stored as: {args.output_folder}/pairwise_ranks.tsv. Cleaning up tmp files ..',

--- a/outrank/task_ranking.py
+++ b/outrank/task_ranking.py
@@ -45,6 +45,12 @@ def outrank_task_conduct_ranking(args: Any) -> None:
 
     dataset_info = get_dataset_info(args)
 
+    if args.label_column not in dataset_info.column_names:
+        raise ValueError(
+            f"Label column '{args.label_column}' not found in dataset columns: "
+            f'{dataset_info.column_names}',
+        )
+
     for arg in vars(args):
         logging.info(f'{arg} set to: {getattr(args, arg)}')
 
@@ -63,100 +69,99 @@ def outrank_task_conduct_ranking(args: Any) -> None:
     global_bounds_storage = []
     global_memory_storage = []
     all_timings = []
-    # Traverse the batches
-    for raw_dump in glob.glob(dataset_info.data_path):
-
-        if (
-            args.data_source == 'ob-vw'
-            or args.data_source == 'ob-csv'
-            or args.data_source == 'csv-raw'
-            or args.data_source == 'ob-raw-dump'
-        ):
-            all_subfiles = [raw_dump]
-
-        for partial_data in all_subfiles:
-            cmd_arguments = {
-                'input_file': partial_data,
-                'fw_col_mapping': dataset_info.fw_map,
-                'column_descriptions': dataset_info.column_names,
-                'numeric_column_types': dataset_info.column_types,
-                'args': args,
-                'data_encoding': dataset_info.encoding,
-                'cpu_pool': GLOBAL_CPU_POOL,
-                'delimiter': dataset_info.col_delimiter,
-                'logger': logging,
-            }
+    try:
+        # Traverse the batches
+        for raw_dump in glob.glob(dataset_info.data_path):
 
             if (
-                args.data_source == 'ob-csv'
-                or args.data_source == 'ob-vw'
+                args.data_source == 'ob-vw'
+                or args.data_source == 'ob-csv'
                 or args.data_source == 'csv-raw'
                 or args.data_source == 'ob-raw-dump'
             ):
-                (
-                    checkpoint_timings,
-                    mutual_information_estimates,
-                    cardinality_object,
-                    bounds_object_storage,
-                    memory_object_storage,
-                    coverage_object,
-                    RARE_VALUE_STORAGE,
-                    GLOBAL_PRIOR_COMB_COUNTS,
-                    GLOBAL_ITEM_COUNTS,
-                    jmi_ranking_result,
-                    interaction_info_result,
-                ) = estimate_importances_minibatches(**cmd_arguments)
+                all_subfiles = [raw_dump]
 
-            global_bounds_storage += bounds_object_storage
-            global_memory_storage += memory_object_storage
-            all_timings += checkpoint_timings
+            for partial_data in all_subfiles:
+                cmd_arguments = {
+                    'input_file': partial_data,
+                    'fw_col_mapping': dataset_info.fw_map,
+                    'column_descriptions': dataset_info.column_names,
+                    'numeric_column_types': dataset_info.column_types,
+                    'args': args,
+                    'data_encoding': dataset_info.encoding,
+                    'cpu_pool': GLOBAL_CPU_POOL,
+                    'delimiter': dataset_info.col_delimiter,
+                    'logger': logging,
+                }
 
-            if cardinality_object is None:
-                continue
+                if (
+                    args.data_source == 'ob-csv'
+                    or args.data_source == 'ob-vw'
+                    or args.data_source == 'csv-raw'
+                    or args.data_source == 'ob-raw-dump'
+                ):
+                    batch_result = estimate_importances_minibatches(**cmd_arguments)
+                    checkpoint_timings = batch_result.step_timing_checkpoints
+                    mutual_information_estimates = batch_result.mutual_information_estimates
+                    cardinality_object = batch_result.cardinality_object
+                    bounds_object_storage = batch_result.bounds_object_storage
+                    memory_object_storage = batch_result.memory_object_storage
+                    coverage_object = batch_result.coverage_object
+                    RARE_VALUE_STORAGE = batch_result.rare_value_storage
+                    GLOBAL_PRIOR_COMB_COUNTS = batch_result.prior_comb_counts
+                    GLOBAL_ITEM_COUNTS = batch_result.item_counts
+                    jmi_ranking_result = batch_result.jmi_ranking
+                    interaction_info_result = batch_result.interaction_info
 
-            if coverage_object is None:
-                continue
+                global_bounds_storage += bounds_object_storage
+                global_memory_storage += memory_object_storage
+                all_timings += checkpoint_timings
 
-            if mutual_information_estimates is not None:
-                global_mutual_information_estimates.append(
-                    mutual_information_estimates,
+                if cardinality_object is None:
+                    continue
+
+                if coverage_object is None:
+                    continue
+
+                if mutual_information_estimates is not None:
+                    global_mutual_information_estimates.append(
+                        mutual_information_estimates,
+                    )
+
+        if args.task == 'identify_rare_values':
+            logging.info('Summarizing rare values ..')
+            summarize_rare_counts(
+                RARE_VALUE_STORAGE, args, cardinality_object, dataset_info,
+            )
+            exit()
+
+        if args.task == 'feature_summary_transformers':
+            summarize_feature_bounds_for_transformers(
+                bounds_object_storage,
+                dataset_info.column_types,
+                args.task,
+                args.label_column,
+            )
+            exit()
+        else:
+            summary_of_numeric_features = summarize_feature_bounds_for_transformers(
+                bounds_object_storage,
+                dataset_info.column_types,
+                args.task,
+                args.label_column,
+                output_summary_table_only=True,
+            )
+            if summary_of_numeric_features is not None:
+                num_out = os.path.join(
+                    args.output_folder, 'numeric_feature_statistics.tsv',
                 )
-
-    if args.task == 'identify_rare_values':
-        logging.info('Summarizing rare values ..')
-        summarize_rare_counts(
-            RARE_VALUE_STORAGE, args, cardinality_object, dataset_info,
-        )
-        exit()
-
-    if args.task == 'feature_summary_transformers':
-        summarize_feature_bounds_for_transformers(
-            bounds_object_storage,
-            dataset_info.column_types,
-            args.task,
-            args.label_column,
-        )
-        exit()
-    else:
-        summary_of_numeric_features = summarize_feature_bounds_for_transformers(
-            bounds_object_storage,
-            dataset_info.column_types,
-            args.task,
-            args.label_column,
-            output_summary_table_only=True,
-        )
-        if summary_of_numeric_features is not None:
-            num_out = os.path.join(
-                args.output_folder, 'numeric_feature_statistics.tsv',
-            )
-            summary_of_numeric_features.to_csv(num_out, sep='\t', index=False)
-            logging.info(
-                f'Stored statistics of numeric features to {num_out} ..',
-            )
-
-    # Just in case.
-    GLOBAL_CPU_POOL.close()
-    GLOBAL_CPU_POOL.join()
+                summary_of_numeric_features.to_csv(num_out, sep='\t', index=False)
+                logging.info(
+                    f'Stored statistics of numeric features to {num_out} ..',
+                )
+    finally:
+        GLOBAL_CPU_POOL.terminate()
+        GLOBAL_CPU_POOL.join()
 
     if len(global_mutual_information_estimates) == 0:
         logging.info('No rankings were obtained, exiting ..')
@@ -305,16 +310,23 @@ def outrank_task_conduct_ranking(args: Any) -> None:
         logging.info(f'JMI feature ranking written to {jmi_path}')
 
     # Write interaction information
+    # Sign convention: Jakulin & Bratko — negative II = synergy, positive = redundancy
     if interaction_info_result is not None:
         ii_path = os.path.join(args.output_folder, 'interaction_information.tsv')
         interaction_info_result.to_csv(ii_path, sep='\t', index=False)
-        logging.info(f'Interaction information written to {ii_path}')
+        logging.info(
+            f'Interaction information written to {ii_path} '
+            '(negative II = synergy, positive = redundancy)',
+        )
 
     logging.info(
         f'Finished with ranking! Result stored as: {args.output_folder}/pairwise_ranks.tsv. Cleaning up tmp files ..',
     )
 
-    os.remove('ranking_checkpoint_tmp.tsv')
+    try:
+        os.remove('ranking_checkpoint_tmp.tsv')
+    except FileNotFoundError:
+        pass
 
 def identify_data_file_type(data_path):
     all_files  = set(list(glob.glob(os.path.join(data_path, '*'))))

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,7 @@ setuptools.setup(
     zip_safe=True,
     include_package_data=True,
     install_requires=_parse_requirements('requirements.txt'),
+    extras_require={
+        'mcp': ['mcp>=1.2.0'],
+    },
 )

--- a/tests/mcp_server_test.py
+++ b/tests/mcp_server_test.py
@@ -1,0 +1,318 @@
+"""Tests for OutRank MCP server tools.
+
+All tests call tool functions directly as regular Python functions — no MCP
+transport needed. The functions return JSON strings which we parse and assert on.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='session')
+def synthetic_data_dir():
+    """Generate a small synthetic dataset for tests. Reused across the session."""
+    tmpdir = tempfile.mkdtemp(prefix='outrank_mcp_test_')
+    rng = np.random.RandomState(42)
+    n = 2000
+    n_features = 30
+
+    # f0-f29: random categorical features with varying cardinality
+    data = {}
+    for i in range(n_features):
+        card = rng.randint(2, 20)
+        data[f'f{i}'] = rng.randint(0, card, size=n)
+
+    # f30: correlated with label (strong signal)
+    label = rng.randint(0, 3, size=n)
+    data['f30'] = label.copy()
+    # Add some noise to f30
+    flip_mask = rng.random(n) < 0.1
+    data['f30'][flip_mask] = rng.randint(0, 3, size=flip_mask.sum())
+
+    data['label'] = label
+
+    df = pd.DataFrame(data)
+    csv_dir = os.path.join(tmpdir, 'data_dir')
+    os.makedirs(csv_dir)
+    df.to_csv(os.path.join(csv_dir, 'data.csv'), index=False)
+
+    yield csv_dir
+
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture(scope='session')
+def xor_data_dir():
+    """Dataset with XOR-like synergy: Y = (X1 + X2) % 3."""
+    tmpdir = tempfile.mkdtemp(prefix='outrank_mcp_xor_')
+    rng = np.random.RandomState(123)
+    n = 5000
+    x1 = rng.randint(0, 3, size=n)
+    x2 = rng.randint(0, 3, size=n)
+    y = (x1 + x2) % 3
+
+    df = pd.DataFrame({'x1': x1, 'x2': x2, 'noise': rng.randint(0, 5, size=n), 'label': y})
+    csv_dir = os.path.join(tmpdir, 'xor_dir')
+    os.makedirs(csv_dir)
+    df.to_csv(os.path.join(csv_dir, 'data.csv'), index=False)
+
+    yield csv_dir
+
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture
+def output_dir():
+    tmpdir = tempfile.mkdtemp(prefix='outrank_mcp_out_')
+    yield tmpdir
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Adapter tests
+# ---------------------------------------------------------------------------
+
+class TestAdapters:
+    def test_build_namespace_defaults(self):
+        from outrank.mcp_adapters import build_ranking_namespace
+
+        ns = build_ranking_namespace()
+        # Verify key defaults match __main__.py
+        assert ns.task == 'ranking'
+        assert ns.heuristic == 'MI-numba-randomized'
+        assert ns.subsampling == 10
+        assert ns.label_column == 'label'
+        assert ns.data_source == 'csv-raw'
+        assert ns.target_ranking_only == 'True'
+        assert ns.disable_tqdm == 'True'
+        assert ns.compute_jmi == 'False'
+        assert ns.compute_interaction_info == 'False'
+        assert ns.num_threads == 4
+        assert ns.minibatch_size == 2**14
+        assert ns.combination_number_upper_bound == 2**15
+
+    def test_bool_string_conversion(self):
+        from outrank.mcp_adapters import build_ranking_namespace
+
+        ns = build_ranking_namespace(
+            target_ranking_only=True,
+            compute_jmi=False,
+            compute_interaction_info=True,
+        )
+        assert ns.target_ranking_only == 'True'
+        assert ns.compute_jmi == 'False'
+        assert ns.compute_interaction_info == 'True'
+
+    def test_overrides_applied(self):
+        from outrank.mcp_adapters import build_ranking_namespace
+
+        ns = build_ranking_namespace(
+            data_path='/some/path',
+            heuristic='AMI',
+            num_threads=16,
+            subsampling=50,
+        )
+        assert ns.data_path == '/some/path'
+        assert ns.heuristic == 'AMI'
+        assert ns.num_threads == 16
+        assert ns.subsampling == 50
+
+    def test_logging_stderr_only(self):
+        """After configure_logging_for_mcp, no handlers should write to stdout."""
+        from outrank.mcp_adapters import configure_logging_for_mcp
+
+        configure_logging_for_mcp()
+        root = logging.getLogger()
+        for handler in root.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                assert handler.stream is not sys.stdout, \
+                    'Found a stdout handler after configure_logging_for_mcp()'
+
+    def test_system_exit_handled(self):
+        """run_ranking_safe should catch SystemExit and other exceptions without propagating."""
+        from outrank.mcp_adapters import build_ranking_namespace, run_ranking_safe
+
+        # Pass an invalid data_path that will cause task_ranking to fail
+        args = build_ranking_namespace(data_path='/nonexistent/path/definitely')
+        # This should NOT raise — errors are captured in the result dict
+        result = run_ranking_safe(args)
+        assert isinstance(result, dict)
+        assert 'output_folder' in result
+        assert 'error' in result  # Should report the error
+
+    def test_dataframe_to_ranking_json(self):
+        from outrank.mcp_adapters import dataframe_to_ranking_json
+
+        df = pd.DataFrame({
+            'FeatureA': ['f1', 'f2', 'f3'],
+            'FeatureB': ['label', 'label', 'label'],
+            'Score': [0.5, 0.3, 0.1],
+        })
+        records = dataframe_to_ranking_json(df, top_n=2)
+        assert len(records) == 2
+        assert records[0]['feature_a'] == 'f1'
+        assert records[0]['score'] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Tool tests
+# ---------------------------------------------------------------------------
+
+class TestListHeuristics:
+    def test_returns_all_heuristics(self):
+        from outrank.mcp_server import outrank_list_heuristics
+
+        result = json.loads(outrank_list_heuristics())
+        assert isinstance(result, list)
+        assert len(result) >= 14
+        names = {h['name'] for h in result}
+        assert 'MI-numba-randomized' in names
+        assert 'AMI' in names
+        assert 'Constant' in names
+
+    def test_heuristic_fields(self):
+        from outrank.mcp_server import outrank_list_heuristics
+
+        result = json.loads(outrank_list_heuristics())
+        for h in result:
+            assert 'name' in h
+            assert 'description' in h
+            assert 'speed' in h
+            assert 'recommended_for' in h
+
+
+class TestDatasetInfo:
+    def test_dataset_info(self, synthetic_data_dir):
+        from outrank.mcp_server import outrank_dataset_info
+
+        result = json.loads(
+            outrank_dataset_info(
+                data_path=synthetic_data_dir,
+                sample_rows=3,
+            ),
+        )
+        assert 'label' in result['columns']
+        assert result['num_rows'] == 2000
+        assert result['num_columns'] == 32  # f0-f30 + label
+        assert len(result['sample_data']) == 3
+        assert 'label' in result['column_cardinalities']
+
+
+class TestGenerateSyntheticData:
+    def test_generate(self, output_dir):
+        from outrank.mcp_server import outrank_generate_synthetic_data
+
+        out_path = os.path.join(output_dir, 'gen_data')
+        # generator_naive uses sample[:, 30] as target, so need >= 31 features
+        result = json.loads(
+            outrank_generate_synthetic_data(
+                output_path=out_path,
+                num_features=50,
+                num_rows=500,
+            ),
+        )
+        assert os.path.exists(result['csv_file'])
+        assert result['actual_shape'] is not None
+        assert result['actual_shape']['rows'] == 500
+        assert result['actual_shape']['columns'] == 51  # 50 features + label
+
+
+class TestScorePair:
+    def test_score_pair_signal_vs_noise(self, synthetic_data_dir):
+        """f30 (correlated with label) should score higher than f0 (random)."""
+        from outrank.mcp_server import outrank_score_pair
+
+        signal = json.loads(
+            outrank_score_pair(
+                data_path=synthetic_data_dir,
+                feature_a='f30',
+                feature_b='label',
+            ),
+        )
+        noise = json.loads(
+            outrank_score_pair(
+                data_path=synthetic_data_dir,
+                feature_a='f0',
+                feature_b='label',
+            ),
+        )
+        assert signal['score'] > noise['score'], \
+            f"Signal feature f30 ({signal['score']:.4f}) should outscore random f0 ({noise['score']:.4f})"
+
+
+class TestInteractionInfo:
+    def test_xor_synergy(self, xor_data_dir):
+        """XOR-like Y=(X1+X2)%3 should show negative II (synergy)."""
+        from outrank.mcp_server import outrank_compute_interaction_info
+
+        result = json.loads(
+            outrank_compute_interaction_info(
+                data_path=xor_data_dir,
+                feature_a='x1',
+                feature_b='x2',
+                label_column='label',
+            ),
+        )
+        assert result['interaction_info'] < 0, \
+            f"XOR synergy should yield negative II, got {result['interaction_info']:.4f}"
+        assert 'synergy' in result['interpretation']
+
+
+class TestRankFeatures:
+    def test_end_to_end_with_jmi_and_summarize(self, synthetic_data_dir, output_dir):
+        """End-to-end: rank with JMI → verify outputs → summarize.
+
+        Runs as a single test because pathos ProcessingPool has global state
+        and cannot be reliably re-created within the same process. Calling
+        outrank_rank_features multiple times in one pytest process triggers
+        'Pool not running' errors. Consolidating into one call avoids this.
+        """
+        from outrank.mcp_server import outrank_rank_features, outrank_summarize_results
+
+        result = json.loads(
+            outrank_rank_features(
+                data_path=synthetic_data_dir,
+                label_column='label',
+                target_ranking_only=True,
+                compute_jmi=True,
+                jmi_top_k=10,
+                subsampling=1,
+                num_threads=2,
+                output_folder=output_dir,
+            ),
+        )
+
+        # Verify pairwise ranking results
+        assert 'pairwise_ranks' in result
+        assert len(result['pairwise_ranks']) > 0
+        assert result['elapsed_seconds'] > 0
+        assert os.path.exists(os.path.join(output_dir, 'pairwise_ranks.tsv'))
+
+        # Verify JMI results
+        assert 'jmi_ranking' in result, 'JMI ranking should be present in results'
+        assert len(result['jmi_ranking']) > 0
+
+        # Verify summarize_results on the same output
+        summary = json.loads(
+            outrank_summarize_results(
+                output_folder=output_dir,
+                top_n=5,
+            ),
+        )
+        assert 'top_pairwise_ranks' in summary
+        assert len(summary['top_pairwise_ranks']) == 5
+        assert 'markdown_table' in summary
+        assert '|' in summary['markdown_table']

--- a/tests/mcp_server_test.py
+++ b/tests/mcp_server_test.py
@@ -2,6 +2,8 @@
 
 All tests call tool functions directly as regular Python functions — no MCP
 transport needed. The functions return JSON strings which we parse and assert on.
+
+Requires: pip install mcp>=1.2.0  (or pip install outrank[mcp])
 """
 from __future__ import annotations
 
@@ -15,6 +17,9 @@ import tempfile
 import numpy as np
 import pandas as pd
 import pytest
+
+# Skip entire module if mcp is not installed (it's an optional dependency)
+pytest.importorskip('mcp', reason='mcp package not installed (optional dependency)')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mi_numba_cmi_test.py
+++ b/tests/mi_numba_cmi_test.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import sys
+import unittest
+
+import numpy as np
+
+from outrank.algorithms.feature_ranking.ranking_mi_numba_cmi import _mi_from_arrays
+from outrank.algorithms.feature_ranking.ranking_mi_numba_cmi import compute_joint_mi_numba
+from outrank.algorithms.feature_ranking.ranking_mi_numba_cmi import conditional_mutual_info_numba
+from outrank.algorithms.feature_ranking.ranking_mi_numba_cmi import interaction_information_numba
+
+sys.path.append('./outrank')
+
+
+class ConditionalMITest(unittest.TestCase):
+
+    def test_cmi_xor_detection(self):
+        """XOR: I(X1;Y) ~ 0 but I(X1;Y|X2) is high — the core synergy case."""
+        np.random.seed(42)
+        n = 5000
+        X1 = np.random.randint(0, 2, size=n, dtype=np.int32)
+        X2 = np.random.randint(0, 2, size=n, dtype=np.int32)
+        Y = np.bitwise_xor(X1, X2).astype(np.int32)
+
+        # Pairwise MI should be near zero
+        mi_x1_y = float(_mi_from_arrays(Y, X1, np.float32(1.0), False))
+        self.assertLess(abs(mi_x1_y), 0.05)
+
+        # Conditional MI should be high — X1 becomes informative once X2 is known
+        cmi = float(conditional_mutual_info_numba(Y, X1, X2, np.float32(1.0), False))
+        self.assertGreater(cmi, 0.5)
+
+    def test_cmi_chain_rule(self):
+        """Chain rule: I(X1,X2;Y) ~ I(X1;Y) + I(X2;Y|X1)"""
+        np.random.seed(42)
+        n = 5000
+        X1 = np.random.randint(0, 4, size=n, dtype=np.int32)
+        X2 = np.random.randint(0, 3, size=n, dtype=np.int32)
+        # Y depends on both
+        Y = ((X1 + X2) % 5).astype(np.int32)
+
+        joint_mi = float(compute_joint_mi_numba(Y, X1, X2, np.float32(1.0), False))
+        mi_x1_y = float(_mi_from_arrays(Y, X1, np.float32(1.0), False))
+        cmi_x2_y_given_x1 = float(conditional_mutual_info_numba(Y, X2, X1, np.float32(1.0), False))
+
+        chain_sum = mi_x1_y + cmi_x2_y_given_x1
+        self.assertAlmostEqual(joint_mi, chain_sum, delta=0.2)
+
+    def test_cmi_reduces_to_mi_when_z_constant(self):
+        """When Z is constant, I(X;Y|Z) = I(X;Y)."""
+        np.random.seed(42)
+        n = 3000
+        X = np.random.randint(0, 3, size=n, dtype=np.int32)
+        Y = X.copy()  # perfect correlation
+        Z = np.zeros(n, dtype=np.int32)  # constant
+
+        cmi = float(conditional_mutual_info_numba(Y, X, Z, np.float32(1.0), False))
+        mi = float(_mi_from_arrays(Y, X, np.float32(1.0), False))
+        self.assertAlmostEqual(cmi, mi, delta=0.05)
+
+    def test_cmi_independent_condition(self):
+        """Z independent of (X,Y) => I(X;Y|Z) ~ I(X;Y)."""
+        np.random.seed(42)
+        n = 5000
+        X = np.random.randint(0, 3, size=n, dtype=np.int32)
+        Y = X.copy()
+        Z = np.random.randint(0, 4, size=n, dtype=np.int32)  # independent noise
+
+        cmi = float(conditional_mutual_info_numba(Y, X, Z, np.float32(1.0), False))
+        mi = float(_mi_from_arrays(Y, X, np.float32(1.0), False))
+        self.assertAlmostEqual(cmi, mi, delta=0.15)
+
+    def test_cmi_non_negative(self):
+        """I(X;Y|Z) >= 0 (without cardinality correction)."""
+        np.random.seed(42)
+        n = 2000
+        X = np.random.randint(0, 5, size=n, dtype=np.int32)
+        Y = np.random.randint(0, 5, size=n, dtype=np.int32)
+        Z = np.random.randint(0, 3, size=n, dtype=np.int32)
+
+        cmi = float(conditional_mutual_info_numba(Y, X, Z, np.float32(1.0), False))
+        self.assertGreaterEqual(cmi, -0.01)
+
+    def test_ii_xor_synergy(self):
+        """XOR -> II < 0 (synergy detected)."""
+        np.random.seed(42)
+        n = 5000
+        X1 = np.random.randint(0, 2, size=n, dtype=np.int32)
+        X2 = np.random.randint(0, 2, size=n, dtype=np.int32)
+        Y = np.bitwise_xor(X1, X2).astype(np.int32)
+
+        ii = interaction_information_numba(Y, X1, X2)
+        self.assertLess(ii, -0.1)
+
+    def test_ii_redundancy(self):
+        """X1=X2=Y -> II > 0 (redundancy)."""
+        np.random.seed(42)
+        n = 5000
+        Y = np.random.randint(0, 3, size=n, dtype=np.int32)
+        X1 = Y.copy()
+        X2 = Y.copy()
+
+        ii = interaction_information_numba(Y, X1, X2)
+        self.assertGreater(ii, 0.1)
+
+    def test_ii_independent_contributions(self):
+        """X1 and X2 provide independent, non-overlapping info about Y -> II ~ 0."""
+        np.random.seed(42)
+        n = 5000
+        # Y is a concatenation of two independent signals: high bits from X1, low bit from X2
+        X1 = np.random.randint(0, 4, size=n, dtype=np.int32)
+        X2 = np.random.randint(0, 2, size=n, dtype=np.int32)
+        # Y encodes both without interaction: Y = X1*2 + X2 (no modular wrap)
+        Y = (X1 * 2 + X2).astype(np.int32)
+
+        ii = interaction_information_numba(Y, X1, X2)
+        # Independent contributions: I(X1,X2;Y) = I(X1;Y) + I(X2;Y), so II ~ 0
+        self.assertLess(abs(ii), 0.15)
+
+    def test_cmi_cardinality_correction(self):
+        """With cardinality correction, high-card Z should yield lower CMI."""
+        np.random.seed(42)
+        n = 3000
+        X = np.random.randint(0, 3, size=n, dtype=np.int32)
+        Y = np.random.randint(0, 3, size=n, dtype=np.int32)
+        # High cardinality Z creates many small groups -> more finite-sample bias
+        Z = np.random.randint(0, 50, size=n, dtype=np.int32)
+
+        cmi_no_corr = float(conditional_mutual_info_numba(Y, X, Z, np.float32(1.0), False))
+        cmi_with_corr = float(conditional_mutual_info_numba(Y, X, Z, np.float32(1.0), True))
+
+        # Correction should reduce the estimate (or at least not inflate it)
+        self.assertLessEqual(cmi_with_corr, cmi_no_corr + 0.05)
+
+    def test_empty_arrays(self):
+        """Empty arrays should return 0."""
+        X = np.array([], dtype=np.int32)
+        Y = np.array([], dtype=np.int32)
+        Z = np.array([], dtype=np.int32)
+
+        result = float(conditional_mutual_info_numba(Y, X, Z, np.float32(1.0), False))
+        self.assertEqual(result, 0.0)
+
+    def test_single_element(self):
+        """Single-element arrays should return a valid float (0 — no entropy)."""
+        X = np.array([1], dtype=np.int32)
+        Y = np.array([0], dtype=np.int32)
+        Z = np.array([2], dtype=np.int32)
+
+        result = float(conditional_mutual_info_numba(Y, X, Z, np.float32(1.0), False))
+        self.assertIsInstance(result, float)
+
+    def test_mismatched_lengths_return_nan(self):
+        """Mismatched array lengths should return NaN."""
+        X = np.array([1, 2], dtype=np.int32)
+        Y = np.array([0], dtype=np.int32)
+        Z = np.array([1, 2], dtype=np.int32)
+
+        result = float(conditional_mutual_info_numba(Y, X, Z, np.float32(1.0), False))
+        self.assertTrue(np.isnan(result))
+
+    def test_joint_mi_consistency(self):
+        """Joint MI should be >= max(I(X1;Y), I(X2;Y)) — joint can't lose info."""
+        np.random.seed(42)
+        n = 3000
+        X1 = np.random.randint(0, 3, size=n, dtype=np.int32)
+        X2 = np.random.randint(0, 3, size=n, dtype=np.int32)
+        Y = ((X1 * 2 + X2) % 5).astype(np.int32)
+
+        joint = float(compute_joint_mi_numba(Y, X1, X2, np.float32(1.0), False))
+        mi_1 = float(_mi_from_arrays(Y, X1, np.float32(1.0), False))
+        mi_2 = float(_mi_from_arrays(Y, X2, np.float32(1.0), False))
+
+        self.assertGreaterEqual(joint + 0.05, max(mi_1, mi_2))
+
+    def test_cmi_subsampling(self):
+        """Subsampling should produce a result in the same ballpark."""
+        np.random.seed(42)
+        n = 5000
+        X = np.random.randint(0, 3, size=n, dtype=np.int32)
+        Y = X.copy()
+        Z = np.random.randint(0, 2, size=n, dtype=np.int32)
+
+        cmi_full = float(conditional_mutual_info_numba(Y, X, Z, np.float32(1.0), False))
+        cmi_sub = float(conditional_mutual_info_numba(Y, X, Z, np.float32(0.5), False))
+
+        # Subsampled should be in the same direction and roughly similar magnitude
+        self.assertGreater(cmi_sub, 0.0)
+        self.assertAlmostEqual(cmi_full, cmi_sub, delta=0.4)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/mi_numba_opt_test.py
+++ b/tests/mi_numba_opt_test.py
@@ -24,7 +24,8 @@ class CompareStrategiesTest(unittest.TestCase):
         b = np.random.random(8).reshape(-1).astype(np.int32)
 
         final_score = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
-        self.assertLess(final_score, 0.0)
+        # b is all zeros (random floats in [0,1) truncate to 0), so MI should be ~0
+        self.assertLessEqual(final_score, 0.0)
 
     def test_mi_numba_mirror(self):
         a = np.array([1, 0, 0, 0, 1, 1, 1, 0], dtype=np.int32)
@@ -95,184 +96,184 @@ class CompareStrategiesTest(unittest.TestCase):
 
         # This must be in the range of identity
         self.assertGreater(score_combined, 0.60)
-    
+
     # === NEW COMPREHENSIVE TESTS ===
-    
+
     def test_empty_arrays(self):
         """Test behavior with empty arrays"""
         a = np.array([], dtype=np.int32)
         b = np.array([], dtype=np.int32)
-        
+
         # Should handle empty arrays gracefully
         with self.assertRaises((IndexError, ValueError)):
             mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
-    
+
     def test_single_element_arrays(self):
         """Test arrays with single elements"""
         a = np.array([1], dtype=np.int32)
         b = np.array([0], dtype=np.int32)
-        
+
         # Single element arrays should work
         result = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
         self.assertIsInstance(result, (float, np.float32))
-    
+
     def test_identical_arrays(self):
         """Test perfectly correlated arrays"""
         a = np.array([1, 2, 3, 1, 2, 3] * 100, dtype=np.int32)
         b = a.copy()
-        
+
         result = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
         # Identical arrays should have high mutual information
         self.assertGreater(result, 0.5)
-    
+
     def test_approximation_factors(self):
         """Test different approximation factors"""
         a = np.array([1, 0, 1, 0, 1, 0] * 1000, dtype=np.int32)
         b = np.array([0, 1, 0, 1, 0, 1] * 1000, dtype=np.int32)
-        
+
         # Test various approximation factors
         for factor in [0.1, 0.5, 1.0]:
             result = mutual_info_estimator_numba_opt(a, b, np.float32(factor), False)
             self.assertIsInstance(result, (float, np.float32))
-            
+
     def test_approximation_factor_edge_cases(self):
         """Test edge cases for approximation factor"""
         a = np.array([1, 0, 1, 0] * 100, dtype=np.int32)
         b = np.array([0, 1, 0, 1] * 100, dtype=np.int32)
-        
+
         # Very small approximation factor
         result = mutual_info_estimator_numba_opt(a, b, np.float32(0.01), False)
         self.assertIsInstance(result, (float, np.float32))
-        
+
         # Approximation factor > 1 (should still work)
         result = mutual_info_estimator_numba_opt(a, b, np.float32(1.5), False)
         self.assertIsInstance(result, (float, np.float32))
-    
+
     def test_cardinality_correction(self):
         """Test cardinality correction flag"""
         a = np.array([1, 0, 1, 0, 1, 0] * 500, dtype=np.int32)
         b = np.array([1, 0, 1, 0, 1, 0] * 500, dtype=np.int32)
-        
+
         # Without cardinality correction
         result_no_corr = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
-        
-        # With cardinality correction  
+
+        # With cardinality correction
         result_with_corr = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), True)
-        
+
         # Both should be valid but may differ
         self.assertIsInstance(result_no_corr, (float, np.float32))
         self.assertIsInstance(result_with_corr, (float, np.float32))
-    
+
     def test_different_array_lengths(self):
         """Test arrays of different lengths (should fail)"""
         a = np.array([1, 0, 1], dtype=np.int32)
         b = np.array([0, 1], dtype=np.int32)
-        
+
         with self.assertRaises((IndexError, ValueError)):
             mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
-    
+
     def test_binary_vs_multiclass(self):
         """Test binary vs multiclass scenarios"""
         # Binary case
         a_binary = np.array([0, 1] * 500, dtype=np.int32)
         b_binary = np.array([1, 0] * 500, dtype=np.int32)
-        
+
         result_binary = mutual_info_estimator_numba_opt(a_binary, b_binary, np.float32(1.0), False)
-        
+
         # Multiclass case
         a_multi = np.array([0, 1, 2] * 333 + [0], dtype=np.int32)
         b_multi = np.array([2, 0, 1] * 333 + [1], dtype=np.int32)
-        
+
         result_multi = mutual_info_estimator_numba_opt(a_multi, b_multi, np.float32(1.0), False)
-        
+
         # Both should be valid
         self.assertIsInstance(result_binary, (float, np.float32))
         self.assertIsInstance(result_multi, (float, np.float32))
-    
+
     def test_extreme_values(self):
         """Test with extreme integer values"""
         max_val = np.iinfo(np.int32).max
         a = np.array([0, max_val] * 100, dtype=np.int32)
         b = np.array([max_val, 0] * 100, dtype=np.int32)
-        
+
         result = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
         self.assertIsInstance(result, (float, np.float32))
-    
+
     def test_all_same_values(self):
         """Test arrays where all values are the same"""
         a = np.array([5] * 1000, dtype=np.int32)
         b = np.array([5] * 1000, dtype=np.int32)
-        
+
         result = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
         # Should handle constant arrays
         self.assertIsInstance(result, (float, np.float32))
-    
+
     def test_large_arrays_performance(self):
         """Test with large arrays for performance validation"""
         size = 50000
         a = np.random.randint(0, 10, size=size, dtype=np.int32)
         b = np.random.randint(0, 10, size=size, dtype=np.int32)
-        
+
         result = mutual_info_estimator_numba_opt(a, b, np.float32(0.1), True)
         self.assertIsInstance(result, (float, np.float32))
-    
+
     def test_deterministic_behavior(self):
         """Test that results are deterministic for same inputs"""
         a = np.array([1, 0, 1, 0, 1] * 200, dtype=np.int32)
         b = np.array([0, 1, 0, 1, 0] * 200, dtype=np.int32)
-        
+
         # Multiple runs should give same result
         result1 = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
-        result2 = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False) 
+        result2 = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
         result3 = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
-        
+
         self.assertEqual(result1, result2)
         self.assertEqual(result2, result3)
-    
+
     def test_independence_detection(self):
         """Test detection of statistical independence"""
         np.random.seed(42)  # For reproducible randomness
-        
+
         # Create independent variables
         a = np.random.randint(0, 3, size=5000, dtype=np.int32)
-        b = np.random.randint(0, 3, size=5000, dtype=np.int32) 
-        
+        b = np.random.randint(0, 3, size=5000, dtype=np.int32)
+
         result = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
-        
+
         # Independent variables should have low mutual information
         # Note: Due to finite sample effects, may not be exactly 0
         self.assertLess(abs(result), 0.2)
-    
+
     def test_functional_relationship(self):
         """Test detection of functional relationships"""
         # Y = f(X) relationship
         a = np.array([0, 1, 2] * 1000, dtype=np.int32)
         b = np.array([0, 2, 4] * 1000, dtype=np.int32)  # b = 2*a
-        
+
         result = mutual_info_estimator_numba_opt(a, b, np.float32(1.0), False)
-        
+
         # Functional relationship should have high mutual information
         self.assertGreater(result, 0.5)
-    
+
     def test_noise_robustness(self):
         """Test robustness to noise in relationship"""
         np.random.seed(999)
-        
+
         # Base relationship
         a = np.array([0, 1] * 2500, dtype=np.int32)
         b_clean = a.copy()
-        
+
         # Add noise (flip 10% of values)
         noise_indices = np.random.choice(len(b_clean), size=len(b_clean)//10, replace=False)
         b_noisy = b_clean.copy()
         b_noisy[noise_indices] = 1 - b_noisy[noise_indices]
-        
+
         result_clean = mutual_info_estimator_numba_opt(a, b_clean, np.float32(1.0), False)
         result_noisy = mutual_info_estimator_numba_opt(a, b_noisy, np.float32(1.0), False)
-        
+
         # Noisy version should have lower MI than clean version
         self.assertLess(result_noisy, result_clean)
-        
+
         # But both should be positive
         self.assertGreater(result_clean, 0.4)
         self.assertGreater(result_noisy, 0.0)

--- a/tests/review_fixes_test.py
+++ b/tests/review_fixes_test.py
@@ -1,0 +1,422 @@
+"""Tests for the review-fix changes.
+
+Covers: MI clamping (Fix 3), label validation (Fix 2), JMI top_k clamping
+(Fix 6), MinibatchResult namedtuple (Fix 4), MCP guards (Fix 5), CLI
+defaults unification (Fix 7).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: MI clamping under cardinality correction
+# ---------------------------------------------------------------------------
+
+class TestMIClampNegativeCC:
+    """Cardinality correction can produce slightly negative MI on independent
+    high-cardinality features. Verify the clamp to >= 0."""
+
+    def test_mi_clamp_negative_cc(self):
+        from outrank.algorithms.feature_ranking.ranking_mi_numba_opt import (
+            mutual_info_estimator_numba_opt,
+        )
+
+        rng = np.random.RandomState(42)
+        n = 500
+        # Independent high-cardinality features — MI should be ~0
+        X = rng.randint(0, 200, size=n).astype(np.int32)
+        Y = rng.randint(0, 200, size=n).astype(np.int32)
+
+        mi = float(mutual_info_estimator_numba_opt(Y, X, np.float32(1.0), True))
+        assert mi >= 0.0, f'MI with CC should be >= 0, got {mi}'
+
+    def test_mi_clamp_negative_cc_contingency(self):
+        """Same test but targeting the contingency table CC path (dx*dy <= 2M)."""
+        from outrank.algorithms.feature_ranking.ranking_mi_numba_opt import (
+            _compute_mi_contingency_cc,
+        )
+
+        rng = np.random.RandomState(99)
+        n = 300
+        X = rng.randint(0, 50, size=n).astype(np.int32)
+        Y = rng.randint(0, 50, size=n).astype(np.int32)
+
+        mi = float(_compute_mi_contingency_cc(Y, X, np.int32(n), np.int32(50), np.int32(50)))
+        assert mi >= 0.0, f'MI (contingency CC) should be >= 0, got {mi}'
+
+    def test_cmi_clamp_negative_cc(self):
+        """CMI path in ranking_mi_numba_cmi.py — CC via _compute_entropies_grouped."""
+        from outrank.algorithms.feature_ranking.ranking_mi_numba_cmi import (
+            _mi_from_arrays,
+        )
+
+        rng = np.random.RandomState(7)
+        n = 500
+        X = rng.randint(0, 200, size=n).astype(np.int32)
+        Y = rng.randint(0, 200, size=n).astype(np.int32)
+
+        mi = float(_mi_from_arrays(Y, X, np.float32(1.0), True))
+        assert mi >= 0.0, f'MI (CMI module, CC) should be >= 0, got {mi}'
+
+    def test_cmi_clamp_negative_cc_contingency_local(self):
+        """CMI module contingency CC path."""
+        from outrank.algorithms.feature_ranking.ranking_mi_numba_cmi import (
+            _compute_mi_contingency_cc_local,
+        )
+
+        rng = np.random.RandomState(11)
+        n = 300
+        X = rng.randint(0, 50, size=n).astype(np.int32)
+        Y = rng.randint(0, 50, size=n).astype(np.int32)
+
+        mi = float(_compute_mi_contingency_cc_local(Y, X, np.int32(n), np.int32(50), np.int32(50)))
+        assert mi >= 0.0, f'MI (CMI contingency CC) should be >= 0, got {mi}'
+
+    def test_mi_positive_signal_unchanged(self):
+        """Ensure clamping doesn't break genuine positive MI."""
+        from outrank.algorithms.feature_ranking.ranking_mi_numba_opt import (
+            mutual_info_estimator_numba_opt,
+        )
+
+        rng = np.random.RandomState(42)
+        n = 5000
+        X = rng.randint(0, 5, size=n).astype(np.int32)
+        Y = X.copy()
+        # Flip 10% to add noise
+        flip = rng.random(n) < 0.1
+        Y[flip] = rng.randint(0, 5, size=flip.sum()).astype(np.int32)
+
+        mi = float(mutual_info_estimator_numba_opt(Y, X, np.float32(1.0), True))
+        assert mi > 0.1, f'Correlated features should have positive MI, got {mi}'
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: Label column validation
+# ---------------------------------------------------------------------------
+
+class TestLabelColumnValidation:
+    def test_missing_label_column_raises(self):
+        """task_ranking should raise ValueError when label column is not in dataset."""
+        from outrank.task_ranking import outrank_task_conduct_ranking
+
+        tmpdir = tempfile.mkdtemp(prefix='outrank_label_test_')
+        try:
+            csv_dir = os.path.join(tmpdir, 'data_dir')
+            os.makedirs(csv_dir)
+            df = pd.DataFrame({'feat1': [1, 2, 3], 'feat2': [4, 5, 6], 'target': [0, 1, 0]})
+            df.to_csv(os.path.join(csv_dir, 'data.csv'), index=False)
+
+            args = argparse.Namespace(
+                task='ranking',
+                data_path=csv_dir,
+                data_source='csv-raw',
+                label_column='nonexistent_label',
+                heuristic='MI-numba-randomized',
+                output_folder=os.path.join(tmpdir, 'out'),
+                disable_tqdm='True',
+                num_threads=1,
+                subsampling=1,
+                minibatch_size=2**14,
+                combination_number_upper_bound=2**15,
+                missing_value_symbols=',{}',
+                include_noise_baseline_features='False',
+                include_cardinality_in_feature_names='False',
+                target_ranking_only='True',
+                transformers='none',
+                feature_set_focus=None,
+                interaction_order=1,
+                reference_model_JSON='',
+                explode_multivalue_features='False',
+                subfeature_mapping='False',
+                max_unique_hist_constraint=30000,
+                mi_stratified_sampling_ratio=1.0,
+                compute_jmi='False',
+                jmi_top_k=50,
+                compute_interaction_info='False',
+                interaction_info_top_k=30,
+                rare_value_count_upper_bound=1,
+                tldr='False',
+            )
+
+            with pytest.raises(ValueError, match='nonexistent_label'):
+                outrank_task_conduct_ranking(args)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Fix 6: JMI top_k clamping
+# ---------------------------------------------------------------------------
+
+class TestJMITopKClamping:
+    def test_jmi_top_k_exceeds_features(self):
+        """JMI should not crash when top_k > number of features."""
+        from outrank.algorithms.importance_estimator import get_importances_estimate_nonmyopic
+
+        rng = np.random.RandomState(42)
+        n = 500
+        # Only 3 features, but top_k=50
+        df = pd.DataFrame({
+            'f0': rng.randint(0, 5, size=n),
+            'f1': rng.randint(0, 5, size=n),
+            'f2': rng.randint(0, 5, size=n),
+            'label': rng.randint(0, 2, size=n),
+        })
+        # Integer-encode via factorize
+        for col in df.columns:
+            df[col] = pd.factorize(df[col])[0].astype(np.int32)
+
+        pairwise = {}
+        for f in ['f0', 'f1', 'f2']:
+            pairwise[(f, 'label')] = rng.random()
+            pairwise[('label', f)] = pairwise[(f, 'label')]
+        # label diagonal
+        pairwise[('label', 'label')] = 1.0
+
+        args = argparse.Namespace(
+            label_column='label',
+            heuristic='MI-numba-randomized',
+            mi_stratified_sampling_ratio=1.0,
+        )
+
+        result = get_importances_estimate_nonmyopic(
+            args, df, pairwise_mi_dict=pairwise, top_k=50,
+        )
+        assert result is not None
+        assert len(result) <= 3, f'Should select at most 3 features, got {len(result)}'
+
+    def test_ii_top_k_exceeds_features(self):
+        """compute_interaction_information_for_pairs with top_k > n_features."""
+        from outrank.algorithms.importance_estimator import compute_interaction_information_for_pairs
+
+        rng = np.random.RandomState(42)
+        n = 500
+        df = pd.DataFrame({
+            'f0': rng.randint(0, 5, size=n),
+            'f1': rng.randint(0, 5, size=n),
+            'label': rng.randint(0, 2, size=n),
+        })
+        for col in df.columns:
+            df[col] = pd.factorize(df[col])[0].astype(np.int32)
+
+        pairwise = {
+            ('f0', 'label'): 0.5, ('label', 'f0'): 0.5,
+            ('f1', 'label'): 0.3, ('label', 'f1'): 0.3,
+            ('label', 'label'): 1.0,
+        }
+
+        args = argparse.Namespace(
+            label_column='label',
+            heuristic='MI-numba-randomized',
+            mi_stratified_sampling_ratio=1.0,
+        )
+
+        result = compute_interaction_information_for_pairs(
+            df, args, pairwise_mi_dict=pairwise, top_k=100,
+        )
+        assert result is not None
+        assert len(result) == 1  # Only 1 pair possible with 2 features
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: MinibatchResult namedtuple
+# ---------------------------------------------------------------------------
+
+class TestMinibatchResult:
+    def test_fields_exist(self):
+        from outrank.core_utils import MinibatchResult
+
+        r = MinibatchResult(
+            step_timing_checkpoints=[{'t': 1.0}],
+            mutual_information_estimates=None,
+            cardinality_object={},
+            bounds_object_storage=[],
+            memory_object_storage=[],
+            coverage_object={},
+            rare_value_storage={},
+            prior_comb_counts={},
+            item_counts={},
+            jmi_ranking=None,
+            interaction_info=None,
+        )
+        assert r.step_timing_checkpoints == [{'t': 1.0}]
+        assert r.mutual_information_estimates is None
+        assert r.jmi_ranking is None
+        assert r.interaction_info is None
+
+    def test_optional_fields_default_none(self):
+        from outrank.core_utils import MinibatchResult
+
+        r = MinibatchResult(
+            step_timing_checkpoints=[],
+            mutual_information_estimates=None,
+            cardinality_object={},
+            bounds_object_storage=[],
+            memory_object_storage=[],
+            coverage_object={},
+            rare_value_storage={},
+            prior_comb_counts={},
+            item_counts={},
+        )
+        assert r.jmi_ranking is None
+        assert r.interaction_info is None
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: MCP server request guards
+# ---------------------------------------------------------------------------
+
+class TestMCPGuards:
+    def test_invalid_data_path(self):
+        from outrank.mcp_adapters import build_ranking_namespace, run_ranking_safe
+
+        args = build_ranking_namespace(data_path='/nonexistent/path/xyz')
+        result = run_ranking_safe(args)
+        assert 'error' in result
+        assert 'does not exist' in result['error']
+
+    def test_none_data_path(self):
+        from outrank.mcp_adapters import build_ranking_namespace, run_ranking_safe
+
+        args = build_ranking_namespace(data_path=None)
+        result = run_ranking_safe(args)
+        assert 'error' in result
+        assert 'must not be None' in result['error']
+
+    def test_file_size_guard(self):
+        from outrank.mcp_adapters import validate_data_path, MAX_FILE_SIZE_MB
+
+        tmpdir = tempfile.mkdtemp(prefix='outrank_size_test_')
+        try:
+            # Create a mock "large" file by patching the threshold
+            import outrank.mcp_adapters as adapters
+            original = adapters.MAX_FILE_SIZE_MB
+            adapters.MAX_FILE_SIZE_MB = 0  # 0 MB limit -> any file is "too large"
+
+            csv_path = os.path.join(tmpdir, 'big.csv')
+            with open(csv_path, 'w') as f:
+                f.write('a,b\n1,2\n')
+
+            with pytest.raises(ValueError, match='exceeding'):
+                validate_data_path(csv_path)
+
+            adapters.MAX_FILE_SIZE_MB = original
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def test_valid_data_path_passes(self):
+        from outrank.mcp_adapters import validate_data_path
+
+        tmpdir = tempfile.mkdtemp(prefix='outrank_valid_test_')
+        try:
+            csv_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(csv_dir)
+            csv_path = os.path.join(csv_dir, 'data.csv')
+            with open(csv_path, 'w') as f:
+                f.write('a,b,label\n1,2,0\n3,4,1\n')
+
+            # Should not raise
+            validate_data_path(csv_dir)
+            validate_data_path(csv_path)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Fix 7: CLI defaults unification
+# ---------------------------------------------------------------------------
+
+class TestCLIDefaultsUnification:
+    def test_cli_defaults_importable(self):
+        from outrank.cli_defaults import CLI_DEFAULTS
+
+        assert isinstance(CLI_DEFAULTS, dict)
+        assert 'label_column' in CLI_DEFAULTS
+        assert CLI_DEFAULTS['label_column'] == 'label'
+        assert CLI_DEFAULTS['heuristic'] == 'MI-numba-randomized'
+
+    def test_mcp_inherits_cli_defaults(self):
+        """MCP adapter should inherit values from CLI_DEFAULTS for shared keys."""
+        from outrank.cli_defaults import CLI_DEFAULTS
+        from outrank.mcp_adapters import build_ranking_namespace
+
+        ns = build_ranking_namespace()
+        # These should match CLI_DEFAULTS (not diverge)
+        assert ns.label_column == CLI_DEFAULTS['label_column']
+        assert ns.heuristic == CLI_DEFAULTS['heuristic']
+        assert ns.minibatch_size == CLI_DEFAULTS['minibatch_size']
+        assert ns.combination_number_upper_bound == CLI_DEFAULTS['combination_number_upper_bound']
+        assert ns.missing_value_symbols == CLI_DEFAULTS['missing_value_symbols']
+        assert ns.compute_jmi == CLI_DEFAULTS['compute_jmi']
+        assert ns.jmi_top_k == CLI_DEFAULTS['jmi_top_k']
+
+    def test_cli_argparse_uses_cli_defaults(self):
+        """CLI argparse defaults should come from CLI_DEFAULTS, not hardcoded."""
+        from outrank.cli_defaults import CLI_DEFAULTS
+        import outrank.__main__ as main_mod
+
+        # Verify the module-level D alias points to CLI_DEFAULTS
+        assert main_mod.D is CLI_DEFAULTS
+
+    def test_cli_mcp_parity_on_shared_keys(self):
+        """All shared keys between CLI and MCP must have the same base default."""
+        from outrank.cli_defaults import CLI_DEFAULTS
+        from outrank.mcp_adapters import build_ranking_namespace
+
+        ns = build_ranking_namespace()
+        # MCP overrides a few keys for headless mode; all others must match
+        mcp_overrides = {
+            'task', 'output_folder', 'data_source', 'num_threads',
+            'disable_tqdm', 'tldr', 'num_synthetic_rows',
+        }
+        for key, cli_val in CLI_DEFAULTS.items():
+            if key in mcp_overrides:
+                continue
+            mcp_val = getattr(ns, key)
+            assert mcp_val == cli_val, (
+                f"Default divergence for '{key}': CLI={cli_val!r}, MCP={mcp_val!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Fix 5 extended: MCP tools that directly read CSV also validate
+# ---------------------------------------------------------------------------
+
+class TestMCPToolValidation:
+    """Verify that MCP tools that directly read CSV files
+    call validate_data_path before processing."""
+
+    def test_dataset_info_rejects_nonexistent(self):
+        pytest.importorskip('mcp', reason='mcp package not installed')
+        from outrank.mcp_server import outrank_dataset_info
+
+        with pytest.raises(ValueError, match='does not exist'):
+            outrank_dataset_info(data_path='/nonexistent/path/xyz')
+
+    def test_score_pair_rejects_nonexistent(self):
+        pytest.importorskip('mcp', reason='mcp package not installed')
+        from outrank.mcp_server import outrank_score_pair
+
+        with pytest.raises(ValueError, match='does not exist'):
+            outrank_score_pair(
+                data_path='/nonexistent/path/xyz',
+                feature_a='a', feature_b='b',
+            )
+
+    def test_interaction_info_rejects_nonexistent(self):
+        pytest.importorskip('mcp', reason='mcp package not installed')
+        from outrank.mcp_server import outrank_compute_interaction_info
+
+        with pytest.raises(ValueError, match='does not exist'):
+            outrank_compute_interaction_info(
+                data_path='/nonexistent/path/xyz',
+                feature_a='a', feature_b='b',
+            )


### PR DESCRIPTION
             
                                                                                                                                                                                        
  - **Conditional Mutual Information (CMI) kernel**: new Numba-JIT'd `ranking_mi_numba_cmi.py` with 3-variable MI estimation (I(X;Y|Z)), interaction information (II), and chain-rule   
  verification. Contingency-table fast path for low-cardinality features, per-Z-group fallback for high cardinality.
  - **JMI greedy feature selection**: `get_importances_estimate_nonmyopic()` implements Joint Mutual Information forward selection — detects XOR-like synergies missed by pairwise MI.
  Incremental score accumulation reduces CMI calls from O(k³) to O(k²).
  - **Interaction information**: `compute_interaction_information_for_pairs()` computes II(Xᵢ, Xⱼ; Y) for top feature pairs. Negative = synergy, positive = redundancy (Jakulin & Bratko
   convention).
  - **Numba MI optimizations (rounds 2-3)**: extracted cold branches to separate `@njit` helpers for better register allocation, sparse iteration for low-density contingency tables, up
   to 6x speedup on high-cardinality features.
  - **MCP server**: `outrank/mcp_server.py` exposes 7 tools (`rank_features`, `score_pair`, `compute_interaction_info`, `generate_synthetic_data`, `summarize_results`,
  `list_heuristics`, `dataset_info`) and 2 resources via FastMCP on stdio transport. Logging redirected to stderr to prevent JSON-RPC corruption. `.mcp.json` enables auto-discovery in
  Claude Code.
  - **New CLI flags**: `--compute_jmi`, `--jmi_top_k`, `--compute_interaction_info`, `--interaction_info_top_k`
